### PR TITLE
OpenAPI Specification for Metadata API for new site

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -1,14 +1,13 @@
-
 openapi: 3.0.1
 info:
   title: Ensembl Web Metadata API
-  description: Metadata API for 2020.ensembl.org
+  description: Metadata API for beta.ensembl.org
   contact:
     email: ensembl-webteam@ebi.ac.uk
   version: 0.0.1
 servers:
-  - url: https://2020.ensembl.org
-  - url: http://2020.ensembl.org
+  - url: https://beta.ensembl.org
+  - url: http://beta.ensembl.org
 tags:
   - name: api
     description: Ensembl Web Metadata API
@@ -109,7 +108,7 @@ components:
         - properties:
             image:
               type: string
-              example: http://2020.ensembl.org/static/genome_images/homo_sapiens_38.svg
+              example: http://beta.ensembl.org/static/genome_images/homo_sapiens_38.svg
             is_available:
               type: boolean
               example: true


### PR DESCRIPTION
This PR is to write the OpenAPI Specification for the Metadata API going to be used new website and it will replace some endpoints from genome-search API.

When ready it will replace following endpoints 

https://beta.ensembl.org/api/genomesearch/popular_genomes
https://beta.ensembl.org/api/genomesearch/genome/info?genome_id=homo_sapiens_GCA_000001405_28

with 

https://beta.ensembl.org/api/metadata/popular_genomes
https://beta.ensembl.org/api/metadata/genome/info?genome_id=a7335667-93e7-11ec-a39d-005056b38ce3


Note that 
-  the metadata API uses genome_uuid. 
- Some fields which were not used in the current endpoints are removed from the metadata API. for example divisions, reference_genome_id etc.

## JIRA
https://www.ebi.ac.uk/panda/jira/secure/RapidBoard.jspa?rapidView=628&view=detail&selectedIssue=EWB-49

## View in Browser
https://editor.swagger.io/?url=https://raw.githubusercontent.com/Ensembl/ensembl-web-metadata-api/openapispec/APISpecification.yaml

## Other Actions
Reitre /api/genomesearch/popular_genomes and /api/genomesearch/genome/info endpoints from the [genome-search API](https://github.com/Ensembl/ensembl-2020-genome-search) when FE/BE is migrated to use genome_uuid.
