### PR TITLE
Fix Stats for Triticum Activum

### DIFF
--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -113,6 +113,8 @@ class GenomeStatistics(BaseModel):
     def __init__(self, **data):
         data["_compiled_data"] = {
             stats_item["name"]: stats_item["statisticValue"]
+            if stats_item["statisticValue"] != "null"
+            else None
             for stats_item in data["_raw_data"]
         }
 

--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -112,9 +112,9 @@ class GenomeStatistics(BaseModel):
 
     def __init__(self, **data):
         data["_compiled_data"] = {
-            si["name"]: si["statisticValue"]
-            for si in data["_raw_data"]
-            if si["statisticValue"] != "null"
+            stats_item["name"]: stats_item["statisticValue"]
+            for stats_item in data["_raw_data"]
+            if stats_item["statisticValue"] != "null"
         }
 
         data["assembly_stats"] = data["_compiled_data"]

--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -112,10 +112,9 @@ class GenomeStatistics(BaseModel):
 
     def __init__(self, **data):
         data["_compiled_data"] = {
-            stats_item["name"]: stats_item["statisticValue"]
-            if stats_item["statisticValue"] != "null"
-            else None
-            for stats_item in data["_raw_data"]
+            si["name"]: si["statisticValue"]
+            for si in data["_raw_data"]
+            if si["statisticValue"] != "null"
         }
 
         data["assembly_stats"] = data["_compiled_data"]


### PR DESCRIPTION
Species Statistics for triticum aestivum

```
$ curl 'https://beta.ensembl.org/api/metadata/genome/a73357ab-93e7-11ec-a39d-005056b38ce3/stats'

$ {"status_code":500,"details":"Internal Server Error"}
```

On the server side
```
api.resources.metadata:get_metadata_statistics:47 - 1 validation error for GenomeStatistics
non_coding_stats -> nc_average_intron_length
  value is not a valid float (type=type_error.float)
```

The data coming out from gRPC may have null values for some stats which is not handled by metadata models. The Pydantic considers  null  as string and tries to convert to whatever type (int,float) which results in an error.

Setting value to None while compiling the data will make pydantic to consider as None and set its value to None. 

```
curl 'localhost:8014/api/metadata/genome/a73357ab-93e7-11ec-a39d-005056b38ce3/stats' | jq '.["genome_stats"]["non_coding_stats"]'

{
  "non_coding_genes": 12853,
  ....
  ....
  "total_introns": 0,
  "average_intron_length": null
}
```

Related JIRA
[ENSWBSITES-2014](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2014)