### PR TITLE
Add openapi spec for popular species

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -37,13 +37,6 @@ paths:
   /api/metadata/popular_species:
     get:
       description: List of 42 groups of genomes related to popular species
-      parameters:
-        - in: query
-          name: selected_genome_ids
-          schema:
-            type: string
-            example: 'a7335667-93e7-11ec-a39d-005056b38ce3,704ceb1-948d-11ec-a39d-005056b38ce3'
-          description: List of genomes already selected by the user; required so that the response can mark which of the popular species contain already selected genomes
       responses:
         '200':
           description: successful operation
@@ -345,15 +338,11 @@ components:
         members_count:
           type: number
           description: The number of genomes associated with this species
-        is_selected:
-          type: boolean
-          description: Whether any of the genomes provided with the query is associated with this species
       required:
         - id
         - name
         - image
         - members_count
-        - is_selected
     GenomeAssociatedWithPopularSpecies:
       properties:
         genome_id:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -76,11 +76,9 @@ paths:
                 properties:
                   group_id:
                     type: string
-                    title: Genome id
                     example: some-id
                   members:
                     type: array
-                    title: Members of the group represented by a popular species
                     items:
                       $ref: '#/components/schemas/GenomeAssociatedWithPopularSpecies'
                   meta:
@@ -99,31 +97,22 @@ components:
           type: object
           properties:
             contig_n50:
-              title: SpeciesStats.assembly_stats.contig_n50
               type: number
             total_genome_length:
-              title: SpeciesStats.assembly_stats.total_genome_length
               type: number
             total_coding_sequence_length:
-              title: SpeciesStats.assembly_stats.total_coding_sequence_length
               type: number
             total_gap_length:
-              title: SpeciesStats.assembly_stats.total_gap_length
               type: number
             spanned_gaps:
-              title: SpeciesStats.assembly_stats.spanned_gaps
               type: number
             chromosomes:
-              title: SpeciesStats.assembly_stats.chromosomes
               type: number
             toplevel_sequences:
-              title: SpeciesStats.assembly_stats.toplevel_sequences
               type: number
             component_sequences:
-              title: SpeciesStats.assembly_stats.component_sequences
               type: number
             gc_percentage:
-              title: SpeciesStats.assembly_stats.gc_percentage
               type: number
           required:
             - contig_n50
@@ -136,64 +125,44 @@ components:
             - component_sequences
             - gc_percentage
           additionalProperties: false
-          title: SpeciesStats.assembly_stats
         coding_stats:
           type: object
           properties:
             coding_genes:
-              title: SpeciesStats.coding_stats.coding_genes
               type: number
             average_genomic_span:
-              title: SpeciesStats.coding_stats.average_genomic_span
               type: number
             average_sequence_length:
-              title: SpeciesStats.coding_stats.average_sequence_length
               type: number
             average_cds_length:
-              title: SpeciesStats.coding_stats.average_cds_length
               type: number
             shortest_gene_length:
-              title: SpeciesStats.coding_stats.shortest_gene_length
               type: number
             longest_gene_length:
-              title: SpeciesStats.coding_stats.longest_gene_length
               type: number
             total_transcripts:
-              title: SpeciesStats.coding_stats.total_transcripts
               type: number
             coding_transcripts:
-              title: SpeciesStats.coding_stats.coding_transcripts
               type: number
             transcripts_per_gene:
-              title: SpeciesStats.coding_stats.transcripts_per_gene
               type: number
             coding_transcripts_per_gene:
-              title: SpeciesStats.coding_stats.coding_transcripts_per_gene
               type: number
             total_exons:
-              title: SpeciesStats.coding_stats.total_exons
               type: number
             total_coding_exons:
-              title: SpeciesStats.coding_stats.total_coding_exons
               type: number
             average_exon_length:
-              title: SpeciesStats.coding_stats.average_exon_length
               type: number
             average_coding_exon_length:
-              title: SpeciesStats.coding_stats.average_coding_exon_length
               type: number
             average_exons_per_transcript:
-              title: SpeciesStats.coding_stats.average_exons_per_transcript
               type: number
             average_coding_exons_per_coding_transcript:
-              title: >-
-                SpeciesStats.coding_stats.average_coding_exons_per_coding_transcript
               type: number
             total_introns:
-              title: SpeciesStats.coding_stats.total_introns
               type: number
             average_intron_length:
-              title: SpeciesStats.coding_stats.average_intron_length
               type: number
           required:
             - coding_genes
@@ -215,54 +184,38 @@ components:
             - total_introns
             - average_intron_length
           additionalProperties: false
-          title: SpeciesStats.coding_stats
         non_coding_stats:
           type: object
           properties:
             non_coding_genes:
-              title: SpeciesStats.non_coding_stats.non_coding_genes
               type: number
             small_non_coding_genes:
-              title: SpeciesStats.non_coding_stats.small_non_coding_genes
               type: number
             long_non_coding_genes:
-              title: SpeciesStats.non_coding_stats.long_non_coding_genes
               type: number
             misc_non_coding_genes:
-              title: SpeciesStats.non_coding_stats.misc_non_coding_genes
               type: number
             average_genomic_span:
-              title: SpeciesStats.non_coding_stats.average_genomic_span
               type: number
             average_sequence_length:
-              title: SpeciesStats.non_coding_stats.average_sequence_length
               type: number
             shortest_gene_length:
-              title: SpeciesStats.non_coding_stats.shortest_gene_length
               type: number
             longest_gene_length:
-              title: SpeciesStats.non_coding_stats.longest_gene_length
               type: number
             total_transcripts:
-              title: SpeciesStats.non_coding_stats.total_transcripts
               type: number
             transcripts_per_gene:
-              title: SpeciesStats.non_coding_stats.transcripts_per_gene
               type: number
             total_exons:
-              title: SpeciesStats.non_coding_stats.total_exons
               type: number
             average_exon_length:
-              title: SpeciesStats.non_coding_stats.average_exon_length
               type: number
             average_exons_per_transcript:
-              title: SpeciesStats.non_coding_stats.average_exons_per_transcript
               type: number
             total_introns:
-              title: SpeciesStats.non_coding_stats.total_introns
               type: number
             average_intron_length:
-              title: SpeciesStats.non_coding_stats.average_intron_length
               type: number
           required:
             - non_coding_genes
@@ -281,45 +234,32 @@ components:
             - total_introns
             - average_intron_length
           additionalProperties: false
-          title: SpeciesStats.non_coding_stats
         pseudogene_stats:
           type: object
           properties:
             pseudogenes:
-              title: SpeciesStats.pseudogene_stats.pseudogenes
               type: number
             average_genomic_span:
-              title: SpeciesStats.pseudogene_stats.average_genomic_span
               type: number
             average_sequence_length:
-              title: SpeciesStats.pseudogene_stats.average_sequence_length
               type: number
             shortest_gene_length:
-              title: SpeciesStats.pseudogene_stats.shortest_gene_length
               type: number
             longest_gene_length:
-              title: SpeciesStats.pseudogene_stats.longest_gene_length
               type: number
             total_transcripts:
-              title: SpeciesStats.pseudogene_stats.total_transcripts
               type: number
             transcripts_per_gene:
-              title: SpeciesStats.pseudogene_stats.transcripts_per_gene
               type: number
             total_exons:
-              title: SpeciesStats.pseudogene_stats.total_exons
               type: number
             average_exon_length:
-              title: SpeciesStats.pseudogene_stats.average_exon_length
               type: number
             average_exons_per_transcript:
-              title: SpeciesStats.pseudogene_stats.average_exons_per_transcript
               type: number
             total_introns:
-              title: SpeciesStats.pseudogene_stats.total_introns
               type: number
             average_intron_length:
-              title: SpeciesStats.pseudogene_stats.average_intron_length
               type: number
           required:
             - pseudogenes
@@ -335,77 +275,51 @@ components:
             - total_introns
             - average_intron_length
           additionalProperties: false
-          title: SpeciesStats.pseudogene_stats
         homology_stats:
           type: object
           properties:
             coverage:
-              title: SpeciesStats.homology_stats.coverage
               type: number
             coverage_explanation:
-              title: SpeciesStats.homology_stats.coverage_explanation
               type: string
           required:
             - coverage
             - coverage_explanation
           additionalProperties: false
-          title: SpeciesStats.homology_stats
         variation_stats:
-          anyOf:
-            - properties:
-                short_variants:
-                  title: SpeciesStats.variation_stats.short_variants
-                  type: number
-                structural_variants:
-                  title: SpeciesStats.variation_stats.structural_variants
-                  type: number
-                short_variants_with_phenotype_assertions:
-                  title: >-
-                    SpeciesStats.variation_stats.short_variants_with_phenotype_assertions
-                  type: number
-                short_variants_with_publications:
-                  title: >-
-                    SpeciesStats.variation_stats.short_variants_with_publications
-                  type: number
-                short_variants_frequency_studies:
-                  title: >-
-                    SpeciesStats.variation_stats.short_variants_frequency_studies
-                  type: number
-                structural_variants_with_phenotype_assertions:
-                  title: >-
-                    SpeciesStats.variation_stats.structural_variants_with_phenotype_assertions
-                  type: number
-              required:
-                - short_variants
-                - structural_variants
-                - short_variants_with_phenotype_assertions
-                - short_variants_with_publications
-                - short_variants_frequency_studies
-                - structural_variants_with_phenotype_assertions
-              additionalProperties: false
-              title: SpeciesStats.variation_stats
-              type: object
-            - title: SpeciesStats.variation_stats
-              nullable: true
-          title: SpeciesStats.variation_stats
+          properties:
+            short_variants:
+              type: number
+            structural_variants:
+              type: number
+            short_variants_with_phenotype_assertions:
+              type: number
+            short_variants_with_publications:
+              type: number
+            short_variants_frequency_studies:
+              type: number
+            structural_variants_with_phenotype_assertions:
+              type: number
+          required:
+            - short_variants
+            - structural_variants
+            - short_variants_with_phenotype_assertions
+            - short_variants_with_publications
+            - short_variants_frequency_studies
+            - structural_variants_with_phenotype_assertions
+          type: object
+          nullable: true
         regulation_stats:
-          anyOf:
-            - type: object
-              properties:
-                enhancers:
-                  title: SpeciesStats.regulation_stats.enhancers
-                  type: number
-                promoters:
-                  title: SpeciesStats.regulation_stats.promoters
-                  type: number
-              required:
-                - enhancers
-                - promoters
-              additionalProperties: false
-              title: SpeciesStats.regulation_stats
-            - title: SpeciesStats.regulation_stats
-              nullable: true
-          title: SpeciesStats.regulation_stats
+          type: object
+          properties:
+            enhancers:
+              type: number
+            promoters:
+              type: number
+          required:
+            - enhancers
+            - promoters
+          nullable: true
       required:
         - assembly_stats
         - coding_stats
@@ -415,29 +329,23 @@ components:
         - variation_stats
         - regulation_stats
       additionalProperties: false
-      title: SpeciesStats
     PopularSpecies:
       type: object
       properties:
         id:
-          title: Id
           anyOf:
             - type: string
             - type: number
         name:
-          title: Name
           type: string
           description: Human-friendly text to show in the tooltip
         image:
-          title: Image url
           type: string
           description: Url of the associated svg
         members_count:
-          title: Members count
           type: number
           description: The number of genomes associated with this species
         is_selected:
-          title: Is selected
           type: boolean
           description: Whether any of the genomes provided with the query is associated with this species
       required:
@@ -449,58 +357,44 @@ components:
     GenomeAssociatedWithPopularSpecies:
       properties:
         genome_id:
-          title: Genome id
           type: string
           example: a7335667-93e7-11ec-a39d-005056b38ce3
         genome_tag:
-          title: Genome tag
           nullable: true
           type: string
           example: grch38
         common_name:
-          title: Species common name
           nullable: true
           type: string
           example: Human
         scientific_name:
-          title: Species scientific name
           type: string
           example: Homo sapiens
         type:
-          title: Group to which the organism belongs
           $ref: '#/components/schemas/SpeciesTypeInGenome'
           nullable: true
         is_reference:
-          title: Is this a reference genome
           type: boolean
         assembly:
-          title: Assembly
           $ref: '#/components/schemas/AssemblyInGenome'
         coding_genes_count:
-          title: Number of coding genes in genome
           type: number
           example: 20446
         contig_n50:
-          title: Contig n50
           nullable: true
           type: number
           example: 56413054
         has_variation:
-          title: Availability of variation data
           type: boolean
         has_regulation:
-          title: Availability of regulation data
           type: boolean
         annotation_provider:
-          title: Annotation provider
           type: string
           example: Ensembl
         annotation_method:
-          title: Annotation method
           type: string
           example: Full genebuild
         rank:
-          title: Search match rank
           nullable: true
           type: number
           example: 1
@@ -520,20 +414,16 @@ components:
         - annotation_method
         - rank
       additionalProperties: false
-      title: SpeciesSearchMatch
       type: object
     AssemblyInGenome:
       properties:
         accession_id:
-          title: Assembly accession id
           type: string
           example: GCA_018466855.1
         name:
-          title: Assembly name
           type: string
           example: HG02559.alt.pat.f1_v2
         url:
-          title: Assembly url
           type: string
           example: https://www.ebi.ac.uk/ena/browser/view/GCA_018466855.1
       required:
@@ -541,22 +431,17 @@ components:
         - name
         - url
       additionalProperties: false
-      title: Assembly in SpeciesSearchMatch
       type: object
     SpeciesTypeInGenome:
       properties:
         kind:
-          title: Kind of the species type
           type: string
           example: population
         value:
-          title: Value of the species type
           type: string
           example: African Caribbean In Barbados
       required:
         - kind
         - value
       additionalProperties: false
-      title: Species type in SpeciesSearchMatch
       type: object
-

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -34,6 +34,62 @@ paths:
                 properties:
                   genome_stats:
                     $ref: '#/components/schemas/SpeciesStats'
+  /api/metadata/popular_species:
+    get:
+      description: List of 42 groups of genomes related to popular species
+      parameters:
+        - in: query
+          name: selected_genome_ids
+          schema:
+            type: string
+            example: 'a7335667-93e7-11ec-a39d-005056b38ce3,704ceb1-948d-11ec-a39d-005056b38ce3'
+          description: List of genomes already selected by the user; required so that the response can mark which of the popular species contain already selected genomes
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  popular_species:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PopularSpecies'
+  /api/metadata/popular_species/{group_id}:
+    get:
+      description: Returns a list of genomes associated with a given popular species
+      parameters:
+        - name: group_id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: some-id
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  group_id:
+                    type: string
+                    title: Genome id
+                    example: some-id
+                  members:
+                    type: array
+                    title: Members of the group represented by a popular species
+                    items:
+                      $ref: '#/components/schemas/GenomeAssociatedWithPopularSpecies'
+                  meta:
+                    type: object
+                    properties:
+                      total_count:
+                        type: number
+
+
 components:
   schemas:
     SpeciesStats:
@@ -360,3 +416,147 @@ components:
         - regulation_stats
       additionalProperties: false
       title: SpeciesStats
+    PopularSpecies:
+      type: object
+      properties:
+        id:
+          title: Id
+          anyOf:
+            - type: string
+            - type: number
+        name:
+          title: Name
+          type: string
+          description: Human-friendly text to show in the tooltip
+        image:
+          title: Image url
+          type: string
+          description: Url of the associated svg
+        members_count:
+          title: Members count
+          type: number
+          description: The number of genomes associated with this species
+        is_selected:
+          title: Is selected
+          type: boolean
+          description: Whether any of the genomes provided with the query is associated with this species
+      required:
+        - id
+        - name
+        - image
+        - members_count
+        - is_selected
+    GenomeAssociatedWithPopularSpecies:
+      properties:
+        genome_id:
+          title: Genome id
+          type: string
+          example: a7335667-93e7-11ec-a39d-005056b38ce3
+        genome_tag:
+          title: Genome tag
+          nullable: true
+          type: string
+          example: grch38
+        common_name:
+          title: Species common name
+          nullable: true
+          type: string
+          example: Human
+        scientific_name:
+          title: Species scientific name
+          type: string
+          example: Homo sapiens
+        type:
+          title: Group to which the organism belongs
+          $ref: '#/components/schemas/SpeciesTypeInGenome'
+          nullable: true
+        is_reference:
+          title: Is this a reference genome
+          type: boolean
+        assembly:
+          title: Assembly
+          $ref: '#/components/schemas/AssemblyInGenome'
+        coding_genes_count:
+          title: Number of coding genes in genome
+          type: number
+          example: 20446
+        contig_n50:
+          title: Contig n50
+          nullable: true
+          type: number
+          example: 56413054
+        has_variation:
+          title: Availability of variation data
+          type: boolean
+        has_regulation:
+          title: Availability of regulation data
+          type: boolean
+        annotation_provider:
+          title: Annotation provider
+          type: string
+          example: Ensembl
+        annotation_method:
+          title: Annotation method
+          type: string
+          example: Full genebuild
+        rank:
+          title: Search match rank
+          nullable: true
+          type: number
+          example: 1
+      required:
+        - genome_id
+        - genome_tag
+        - common_name
+        - scientific_name
+        - type
+        - is_reference
+        - assembly
+        - coding_genes_count
+        - contig_n50
+        - has_variation
+        - has_regulation
+        - annotation_provider
+        - annotation_method
+        - rank
+      additionalProperties: false
+      title: SpeciesSearchMatch
+      type: object
+    AssemblyInGenome:
+      properties:
+        accession_id:
+          title: Assembly accession id
+          type: string
+          example: GCA_018466855.1
+        name:
+          title: Assembly name
+          type: string
+          example: HG02559.alt.pat.f1_v2
+        url:
+          title: Assembly url
+          type: string
+          example: https://www.ebi.ac.uk/ena/browser/view/GCA_018466855.1
+      required:
+        - accession_id
+        - name
+        - url
+      additionalProperties: false
+      title: Assembly in SpeciesSearchMatch
+      type: object
+    SpeciesTypeInGenome:
+      properties:
+        kind:
+          title: Kind of the species type
+          type: string
+          example: population
+        value:
+          title: Value of the species type
+          type: string
+          example: African Caribbean In Barbados
+      required:
+        - kind
+        - value
+      additionalProperties: false
+      title: Species type in SpeciesSearchMatch
+      type: object
+


### PR DESCRIPTION
## Description
This PR proposes schemas for the endpoints related to popular species:
- An endpoint to get a list of 42 popular species shown on the main screen of Species Selector.
- An endpoint to return a list of all genomes associated with a given popular species

I've been struggling with the names, both the ones used in proposed url paths and the ones used in schemas. I don't particularly like these names; but I couldn't think of anything better.

## Related Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2023

Related PR in GitLab: https://gitlab.ebi.ac.uk/ensembl-web/ensembl_search_hub/-/merge_requests/6