### PR TITLE
Add open api  spec for genome details

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -448,9 +448,9 @@ components:
           description: Link to species image, if present
           example: http://beta.ensembl.org/static/genome_images/homo_sapiens_38.svg
           nullable: true
-        related_genomes_count:
+        number_of_genomes_in_group:
           type: number
-          description: The number of genomes related to the current one via species taxonomy id.
+          description: The number of genomes, including the current one, that share the same species taxonomy id.
             May just mean the number of alternative assemblies; but may also include genomes
             that have the same assembly, but different annotations.
       required:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -70,39 +70,6 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/PopularSpecies'
-  /api/metadata/genomes
-    get:
-      tags:
-        - api
-      description: Returns a list of genomes associated with a given popular species
-      parameters:
-        - name: species_taxonomy_id
-          in: query
-          required: true
-          schema:
-            type: string
-            example: "9606"
-      responses:
-        '200':
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  group_id:
-                    type: string
-                    example: some-id
-                  members:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/GenomeMatch'
-                  meta:
-                    type: object
-                    properties:
-                      total_count:
-                        type: number
-
 
 components:
   schemas:
@@ -366,67 +333,6 @@ components:
         - name
         - image
         - members_count
-    GenomeMatch:
-      properties:
-        genome_id:
-          type: string
-          example: a7335667-93e7-11ec-a39d-005056b38ce3
-        genome_tag:
-          nullable: true
-          type: string
-          example: grch38
-        common_name:
-          nullable: true
-          type: string
-          example: Human
-        scientific_name:
-          type: string
-          example: Homo sapiens
-        type:
-          $ref: '#/components/schemas/SpeciesTypeInGenome'
-          nullable: true
-        is_reference:
-          type: boolean
-        assembly:
-          $ref: '#/components/schemas/AssemblyInGenome'
-        coding_genes_count:
-          type: number
-          example: 20446
-        contig_n50:
-          nullable: true
-          type: number
-          example: 56413054
-        has_variation:
-          type: boolean
-        has_regulation:
-          type: boolean
-        annotation_provider:
-          type: string
-          example: Ensembl
-        annotation_method:
-          type: string
-          example: Full genebuild
-        rank:
-          nullable: true
-          type: number
-          example: 1
-      required:
-        - genome_id
-        - genome_tag
-        - common_name
-        - scientific_name
-        - type
-        - is_reference
-        - assembly
-        - coding_genes_count
-        - contig_n50
-        - has_variation
-        - has_regulation
-        - annotation_provider
-        - annotation_method
-        - rank
-      additionalProperties: false
-      type: object
     AssemblyInGenome:
       properties:
         accession_id:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -344,6 +344,7 @@ components:
         url:
           type: string
           example: https://www.ebi.ac.uk/ena/browser/view/GCA_018466855.1
+          nullable: true
       required:
         - accession_id
         - name

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -70,18 +70,18 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/PopularSpecies'
-  /api/metadata/popular_species/{group_id}:
+  /api/metadata/genomes
     get:
       tags:
         - api
       description: Returns a list of genomes associated with a given popular species
       parameters:
-        - name: group_id
-          in: path
+        - name: species_taxonomy_id
+          in: query
           required: true
           schema:
             type: string
-            example: some-id
+            example: "9606"
       responses:
         '200':
           description: successful operation
@@ -96,7 +96,7 @@ paths:
                   members:
                     type: array
                     items:
-                      $ref: '#/components/schemas/GenomeAssociatedWithPopularSpecies'
+                      $ref: '#/components/schemas/GenomeMatch'
                   meta:
                     type: object
                     properties:
@@ -366,7 +366,7 @@ components:
         - name
         - image
         - members_count
-    GenomeAssociatedWithPopularSpecies:
+    GenomeMatch:
       properties:
         genome_id:
           type: string

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -411,6 +411,7 @@ components:
         common_name:
           type: string
           example: human
+          nullable: true
         scientific_name:
           type: string
           example: Homo sapiens

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -33,9 +33,30 @@ paths:
                 type: object
                 properties:
                   genome_stats:
-                    $ref: '#/components/schemas/SpeciesStats'
+                    $ref: '#/components/schemas/GenomeStats'
+  /api/metadata/genome/{genome_id}/details:
+    get:
+      tags:
+        - api
+      description: Detailed information about a genome
+      parameters:
+        - name: genome_id
+          in: path
+          required: true
+          schema:
+            type: string
+            default: a7335667-93e7-11ec-a39d-005056b38ce3
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenomeDetails'
   /api/metadata/popular_species:
     get:
+      tags:
+        - api
       description: List of 42 groups of genomes related to popular species
       responses:
         '200':
@@ -51,6 +72,8 @@ paths:
                       $ref: '#/components/schemas/PopularSpecies'
   /api/metadata/popular_species/{group_id}:
     get:
+      tags:
+        - api
       description: Returns a list of genomes associated with a given popular species
       parameters:
         - name: group_id
@@ -83,7 +106,7 @@ paths:
 
 components:
   schemas:
-    SpeciesStats:
+    GenomeStats:
       type: object
       properties:
         assembly_stats:
@@ -421,6 +444,32 @@ components:
         - url
       additionalProperties: false
       type: object
+    AssemblyProvider:
+      type: object
+      properties:
+        name:
+          type: string
+          example: UCSC Genomics Institute
+        url:
+          type: string
+          example: https://genomics.ucsc.edu
+          nullable: true
+      required:
+        - name
+        - url
+    AnnotationProvider:
+      type: object
+      properties:
+        name:
+          type: string
+          example: UCSC Genomics Institute
+        url:
+          type: string
+          example: https://genomics.ucsc.edu
+          nullable: true
+      required:
+        - name
+        - url
     SpeciesTypeInGenome:
       properties:
         kind:
@@ -432,5 +481,89 @@ components:
       required:
         - kind
         - value
+      additionalProperties: false
+      type: object
+    GenomeDetails:
+      properties:
+        genome_id:
+          type: string
+          example: a7335667-93e7-11ec-a39d-005056b38ce3
+        genome_tag:
+          type: string
+          example: grch38
+          nullable: true
+        taxonomy_id:
+          type: string
+          example: "9606"
+          description: Identifier of the taxon that the genome belongs to.
+            May be the same as species_taxonomy_id, or different.
+        species_taxonomy_id:
+          type: string
+          example: "1"
+          description: required to be able to retrieve a list of related genomes
+        common_name:
+          type: string
+          example: human
+        scientific_name:
+          type: string
+          example: Homo sapiens
+        type:
+          $ref: '#/components/schemas/SpeciesTypeInGenome'
+          nullable: true
+        is_reference:
+          type: boolean
+        assembly:
+          $ref: '#/components/schemas/AssemblyInGenome'
+        assembly_provider:
+          $ref: '#/components/schemas/AssemblyProvider'
+        assembly_level:
+          type: string
+          example: complete genome
+        assembly_date:
+          type: string
+          description: ISO date string in the YYYY-MM format
+          example: "2019-02"
+        annotation_provider:
+          $ref: '#/components/schemas/AnnotationProvider'
+        annotation_method:
+          type: string
+          example: import
+        annotation_version:
+          type: string
+          example: GENCODE 34
+          nullable: true
+        annotation_date:
+          type: string
+          description: ISO date string in the YYYY-MM format
+          example: "2019-02"
+        image_url:
+          type: string
+          description: Link to species image, if present
+          example: http://beta.ensembl.org/static/genome_images/homo_sapiens_38.svg
+          nullable: true
+        related_genomes_count:
+          type: number
+          description: The number of genomes related to the current one via species taxonomy id.
+            May just mean the number of alternative assemblies; but may also include genomes
+            that have the same assembly, but different annotations.
+      required:
+        - genome_id
+        - genome_tag
+        - taxonomy_id
+        - species_taxonomy_id
+        - common_name
+        - scientific_name
+        - type
+        - is_reference
+        - assembly
+        - assembly_provider
+        - assembly_level
+        - assembly_date
+        - annotation_provider
+        - annotation_method
+        - annotation_version
+        - annotation_date
+        - image_url
+        - related_genomes_count
       additionalProperties: false
       type: object


### PR DESCRIPTION
## Description
1. Added a schema for genome details payload to support [this design](https://xd.adobe.com/view/b8d67194-34d7-40de-bcd9-a3413ea5d727-ed85/screen/12bcb450-f75e-4cca-be29-3edad1760297?fullscreen)

Its typescript equivalent (might be easier to read) is:

```ts
type GenomeDetailedInformation = {
  genome_id: string;
  genome_tag: string | null;
  taxonomy_id: string;
  species_taxonomy_id: string; // to be able to retrieve a list of related assemblies
  common_name: string | null;
  scientific_name: string;
  type: {
    kind: string;
    value: string;
  } | null;
  is_reference: boolean;
  assembly: {
    accession_id: string;
    name: string;
    url: string | null;
  };
  assembly_provider: {
    name: string;
    url: string | null;
  };
  assembly_level: string;
  assembly_date: string; // ISO date string in YYYY-MM format
  annotation_provider: {
    name: string;
    url: string | null;
  };
  annotation_method: string;
  annotation_version: string | null;
  annotation_date: string; // ISO date string in YYYY-MM format
  image_url: string | null;
  number_of_genomes_in_group: number; // at least 1, i.e. the current genome itself
}
```

2. Changed path for another endpoint: `/api/metadata/popular_species/{group_id}` -> `/api/metadata/genomes`; because the mechanism to get a list of genomes based on species taxonomy id is generic and not restricted to popular species.


## Related Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2025