### PR TITLE
Update regulation fields

### DIFF
--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -11,8 +11,8 @@ class Homology(BaseModel):
 
 
 class Regulation(BaseModel):
-    enhancers: int = Field(alias="promoter.count", default=None)
-    promoters: int = Field(alias="enhancer.count", default=None)
+    enhancers: int = Field(alias="regulation.promoter.count", default=None)
+    promoters: int = Field(alias="regulation.enhancer.count", default=None)
 
 
 class Pseudogene(BaseModel):


### PR DESCRIPTION
The regulation fields are renamed in the messages coming out of gRPC service.

This PR re maps the fields to the new name

Current Behaviour

```
curl 'https://staging-2020.ensembl.org/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/stats' | jq '.genome_stats.regulation_stats'
{
  "enhancers": null,
  "promoters": null
}
```

With the change 

```
curl 'http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/stats' | jq '.genome_stats.regulation_stats'
{
  "enhancers": 36597,
  "promoters": 268483
}
```