### PR TITLE
Add new fields for regulation stats

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -432,9 +432,21 @@ components:
               type: number
             promoters:
               type: number
+            open_chromatin_count:
+              type: number
+              nullable: true
+            ctcf_count:
+              type: number
+              nullable: true
+            tfbs_count:
+              type: number
+              nullable: true
           required:
             - enhancers
             - promoters
+            - open_chromatin_count
+            - ctcf_count
+            - tfbs_count
           nullable: true
       required:
         - assembly_stats


### PR DESCRIPTION
Updated stats endpoint to include new statistics from Regulation

See [ENSWBSITES-2213](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2213) for attribute names in Production db.