### PR TITLE
Example Object endpoint

### DIFF
--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -146,7 +146,7 @@ class ExampleObject(BaseModel):
     type: str
     id: str
 
-class ExampleObjects(BaseModel):
+class ExampleObjectList(BaseModel):
     example_objects:  List[ExampleObject] = []
 
     @root_validator(pre=True)
@@ -161,14 +161,14 @@ class ExampleObjects(BaseModel):
             for stats_item in samples_input:
                 try:
                     if stats_item["name"] == "genebuild.sample_gene":
-                        e_g = ExampleObject(type="gene", id=stats_item["statisticValue"])
-                        extracted_samples.append(e_g)
+                        example_gene = ExampleObject(type="gene", id=stats_item["statisticValue"])
+                        extracted_samples.append(example_gene)
                     if stats_item["name"] == "genebuild.sample_location":
-                        e_l = ExampleObject(type="location", id=stats_item["statisticValue"])
-                        extracted_samples.append(e_l)
+                        example_location = ExampleObject(type="location", id=stats_item["statisticValue"])
+                        extracted_samples.append(example_location)
                     if stats_item["name"] == "variation.sample_variant":
-                        e_v = ExampleObject(type="variant", id=stats_item["statisticValue"])
-                        extracted_samples.append(e_v)
+                        example_variant = ExampleObject(type="variant", id=stats_item["statisticValue"])
+                        extracted_samples.append(example_variant)
                 except KeyError as ke:
                     logger.debug(stats_item["name"], ke)
         except Exception as ex:

--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -151,26 +151,26 @@ class ExampleObjectList(BaseModel):
 
     @root_validator(pre=True)
     def set_region_parameters(cls, values):
-        extracted_example_objects = cls.extract_samples(values.get("example_objects"))
+        extracted_example_objects = cls.extract_example_objects(values.get("example_objects"))
         values["example_objects"] = extracted_example_objects
         return values
 
-    def extract_samples(samples_input):
-        extracted_samples = []
+    def extract_example_objects(genome_attribute_list):
+        extracted_example_objects = []
         try:
-            for stats_item in samples_input:
+            for genome_attribute in genome_attribute_list:
                 try:
-                    if stats_item["name"] == "genebuild.sample_gene":
-                        example_gene = ExampleObject(type="gene", id=stats_item["statisticValue"])
-                        extracted_samples.append(example_gene)
-                    if stats_item["name"] == "genebuild.sample_location":
-                        example_location = ExampleObject(type="location", id=stats_item["statisticValue"])
-                        extracted_samples.append(example_location)
-                    if stats_item["name"] == "variation.sample_variant":
-                        example_variant = ExampleObject(type="variant", id=stats_item["statisticValue"])
-                        extracted_samples.append(example_variant)
+                    if genome_attribute["name"] == "genebuild.sample_gene":
+                        example_gene = ExampleObject(type="gene", id=genome_attribute["statisticValue"])
+                        extracted_example_objects.append(example_gene)
+                    if genome_attribute["name"] == "genebuild.sample_location":
+                        example_location = ExampleObject(type="location", id=genome_attribute["statisticValue"])
+                        extracted_example_objects.append(example_location)
+                    if genome_attribute["name"] == "variation.sample_variant":
+                        example_variant = ExampleObject(type="variant", id=genome_attribute["statisticValue"])
+                        extracted_example_objects.append(example_variant)
                 except KeyError as ke:
-                    logger.debug(stats_item["name"], ke)
+                    logger.debug(genome_attribute["name"], ke)
         except Exception as ex:
             logger.debug("Error : ",ex)
-        return extracted_samples
+        return extracted_example_objects

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Request, responses
 from loguru import logger
 
 from api.error_response import response_error_handler
-from api.models.statistics import GenomeStatistics, ExampleObjects
+from api.models.statistics import GenomeStatistics, ExampleObjectList
 from api.models.popular_species import PopularSpeciesGroup
 from api.models.karyotype import Karyotype
 from core.config import GRPC_HOST, GRPC_PORT
@@ -91,7 +91,7 @@ def example_objects(request: Request, genome_id: str):
     try:
         top_level_stats_eo_dict = MessageToDict(grpc_client.get_statistics(genome_id))
 
-        objects = ExampleObjects(example_objects=top_level_stats_eo_dict["statistics"])
+        objects = ExampleObjectList(example_objects=top_level_stats_eo_dict["statistics"])
         return responses.JSONResponse(objects.dict()["example_objects"])
     except Exception as e:
         logger.debug(e)

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Request, responses
 from loguru import logger
 
 from api.error_response import response_error_handler
-from api.models.statistics import GenomeStatistics
+from api.models.statistics import GenomeStatistics, ExampleObjects
 from api.models.popular_species import PopularSpeciesGroup
 from api.models.karyotype import Karyotype
 from core.config import GRPC_HOST, GRPC_PORT
@@ -82,6 +82,17 @@ def validate_region(request: Request, genome_id: str, location: str):
         rgv = RegionValidation(genome_uuid=genome_id, location_input=location)
         rgv.validate_region()
         return responses.JSONResponse(rgv.dict())
+    except Exception as e:
+        logger.debug(e)
+        return response_error_handler({"status": 500})
+
+@router.get("/genome/{genome_id}/example_objects", name="example_objects")
+def example_objects(request: Request, genome_id: str):
+    try:
+        top_level_stats_eo_dict = MessageToDict(grpc_client.get_statistics(genome_id))
+
+        objects = ExampleObjects(example_objects=top_level_stats_eo_dict["statistics"])
+        return responses.JSONResponse(objects.dict()["example_objects"])
     except Exception as e:
         logger.debug(e)
         return response_error_handler({"status": 500})


### PR DESCRIPTION
Description

Implement new endpoint example_objects which will return list of objects containing  gene, location, variant example

Related JIRA

https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2221

See it in Action

```
curl 'https://staging-2020.ensembl.org/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/example_objects' | jq
```

Please note  data on _stage is out of date as compared to stage-1 so once it is synced it the actual data will appear
Local using stage-1


```
curl 'http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/example_objects' \| jq
[
    {
        "type": "gene",
        "id": "ENSG00000221914"
    },
    {
        "type": "location",
        "id": "8:26291508-26372680"
    }
]
```
