### PR TITLE
explain endpoint 

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -183,12 +183,15 @@ components:
         scientific_name:
           type: string
           example: Homo sapiens
-        assembly_accession_id:
-          type: string
-          example: GCA_000001405.28
-        assembly_name:
-          type: string
-          example: GRCh38.p13
+        assembly:
+          type: object
+          properties:
+            accession_id:
+              type: string
+              example: GCA_000001405.28
+            name:
+              type: string
+              example: GRCh38.p13
         type:
           $ref: '#/components/schemas/SpeciesTypeInGenome'
           nullable: true

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -81,3 +81,8 @@ class GRPCClient:
         )
         genome_seq_region = self.stub.GetGenomeAssemblySequenceRegion(genome_seq_region_request)
         return genome_seq_region
+
+    def get_genome_uuid_from_slug(self, slug):
+        uuid_request = ensembl_metadata_pb2.GenomeTagRequest(genome_tag=slug)
+        genome_uuid_data = self.stub.GetGenomeUUIDByTag(uuid_request)
+        return genome_uuid_data.genome_uuid

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -115,5 +115,5 @@ async def explain_genome(request: Request, slug: str):
     if genome_uuid:
         genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
         genome_details = GenomeDetails(**genome_details_dict)
-        response_dict = genome_details.model_dump(include={"genome_id":True, "genome_tag":True, "scientific_name":True, "common_name":True, "is_reference" : True, "assembly_accession_id": True, "assembly_name": True, "type": True})
+        response_dict = genome_details.model_dump(include={"genome_id":True, "genome_tag":True, "scientific_name":True, "common_name":True, "is_reference" : True, "assembly": {"name", "accession_id"}, "type": True})
     return responses.JSONResponse(response_dict)

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -107,3 +107,13 @@ async def get_genome_details(request: Request, genome_uuid: str):
     genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
     genome_details = GenomeDetails(**genome_details_dict)
     return responses.JSONResponse(genome_details.dict())
+
+@router.get("/genome/{slug}/explain", name="genome_explain")
+async def explain_genome(request: Request, slug: str):
+    genome_uuid = grpc_client.get_genome_uuid_from_slug(slug)
+    response_dict = {}
+    if genome_uuid:
+        genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
+        genome_details = GenomeDetails(**genome_details_dict)
+        response_dict = genome_details.model_dump(include={"genome_id":True, "genome_tag":True, "scientific_name":True, "common_name":True, "is_reference" : True, "assembly_accession_id": True, "assembly_name": True, "type": True})
+    return responses.JSONResponse(response_dict)


### PR DESCRIPTION
### Description

The PR implements /genome/{slug}/explain endpoint
It uses existing genome models.

- Find out genome_id for the given slug
- get the genome details from genome_id
- filter the results

### Related JIRA
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2220

### Example
wheat
```
curl 'http://localhost:8014/api/metadata/genome/iwgsc/explain' | jq                         
{
  "genome_id": "a73357ab-93e7-11ec-a39d-005056b38ce3",
  "genome_tag": "iwgsc",
  "common_name": "bread wheat",
  "scientific_name": "Triticum aestivum",
  "type": {
    "kind": "cultivar",
    "value": "Chinese Spring"
  },
  "is_reference": true,
  "assembly": {
    "accession_id": "GCA_900519105.1",
    "name": "IWGSC"
  }
}

```
grch38
```
curl 'http://localhost:8014/api/metadata/genome/grch38/explain' | jq
{
  "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3",
  "genome_tag": "grch38",
  "common_name": "human",
  "scientific_name": "Homo sapiens",
  "type": null,
  "is_reference": true,
  "assembly": {
    "accession_id": "GCA_000001405.29",
    "name": "GRCh38.p14"
  }
}
```

### Note 
The PR should be merged after https://github.com/Ensembl/ensembl-web-metadata-api/pull/26 