### PR TITLE
explain should accept slug or uuid

### DIFF
--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -51,8 +51,8 @@ class GenomeDetails(BaseModel):
     assembly_level: str = Field(alias=AliasPath('attributesInfo', 'assemblyLevel'))
     assembly_date: str = Field(alias=AliasPath('attributesInfo', 'assemblyDate'), default=None)
     annotation_provider: AnnotationProvider = None
-    annotation_method: str = Field(alias='genebuildMethod', default=None)
-    annotation_version: str = Field(alias='genebuildVersion', default=None)
+    annotation_method: str = Field(alias=AliasPath('attributesInfo', 'genebuildMethod'), default=None)
+    annotation_version: str = Field(alias=AliasPath('attributesInfo', 'genebuildVersion'), default=None)
     annotation_date: str = Field(alias='created', default=None)
     number_of_genomes_in_group: int = Field(alias='relatedAssembliesCount', default=1)
 
@@ -78,8 +78,8 @@ class GenomeDetails(BaseModel):
             }
         if data.get("attributesInfo", {}).get('annotationProviderName', None):
             data["annotation_provider"] = {
-                "name": data.get("attributesInfo", {}).get("annotationProviderName", None),
-                "url": data.get("attributesInfo", {}).get("annotationProviderUrl", None),
+                "name": data.get("attributesInfo", {}).get("genebuildProviderName", None),
+                "url": data.get("attributesInfo", {}).get("genebuildProviderUrl", None),
             }
 
         super().__init__(**data)

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -82,9 +82,9 @@ class GRPCClient:
         genome_seq_region = self.stub.GetGenomeAssemblySequenceRegion(genome_seq_region_request)
         return genome_seq_region
 
-    def get_genome_uuid_from_slug(self, slug):
-        uuid_request = ensembl_metadata_pb2.GenomeTagRequest(genome_tag=slug)
+    def get_genome_uuid_from_tag(self, tag):
+        uuid_request = ensembl_metadata_pb2.GenomeTagRequest(genome_tag=tag)
         genome_uuid_data = self.stub.GetGenomeUUIDByTag(uuid_request)
         if genome_uuid_data.genome_uuid:
             return genome_uuid_data.genome_uuid
-        return slug
+        return None

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -85,4 +85,6 @@ class GRPCClient:
     def get_genome_uuid_from_slug(self, slug):
         uuid_request = ensembl_metadata_pb2.GenomeTagRequest(genome_tag=slug)
         genome_uuid_data = self.stub.GetGenomeUUIDByTag(uuid_request)
-        return genome_uuid_data.genome_uuid
+        if genome_uuid_data.genome_uuid:
+            return genome_uuid_data.genome_uuid
+        return slug

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -119,15 +119,13 @@ async def get_genome_details(request: Request, genome_uuid: str):
 
 @router.get("/genome/{slug}/explain", name="genome_explain")
 async def explain_genome(request: Request, slug: str):
-    uuid_from_tag = grpc_client.get_genome_uuid_from_tag(slug)
+    genome_uuid = grpc_client.get_genome_uuid_from_tag(slug)
     response_dict = {}
     response_data = None
-    if uuid_from_tag:
-        genome_detail_for_genome = uuid_from_tag
-    else:
-        genome_detail_for_genome = slug
+    if not genome_uuid:
+        genome_uuid = slug
     try:
-        genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_detail_for_genome))
+        genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
         if genome_details_dict:
             genome_details = GenomeDetails(**genome_details_dict)
             response_dict = genome_details.model_dump(include={"genome_id":True, "genome_tag":True, "scientific_name":True, "common_name":True, "is_reference" : True, "assembly": {"name", "accession_id"}, "type": True})

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -104,9 +104,18 @@ def example_objects(request: Request, genome_id: str):
 
 @router.get("/genome/{genome_uuid}/details", name="genome_details")
 async def get_genome_details(request: Request, genome_uuid: str):
-    genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
-    genome_details = GenomeDetails(**genome_details_dict)
-    return responses.JSONResponse(genome_details.dict())
+    response_data = None
+    try:
+        genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
+        if genome_details_dict:
+            genome_details = GenomeDetails(**genome_details_dict)
+            response_data = responses.JSONResponse(genome_details.dict())
+        else:
+            not_found_response = {"message": "Could not find details for {}".format(genome_uuid)}
+            response_data = responses.JSONResponse(not_found_response, status_code=404)
+    except Exception as ex:
+        logger.log("DEBUG", ex)
+    return response_data
 
 @router.get("/genome/{slug}/explain", name="genome_explain")
 async def explain_genome(request: Request, slug: str):
@@ -124,7 +133,7 @@ async def explain_genome(request: Request, slug: str):
             response_dict = genome_details.model_dump(include={"genome_id":True, "genome_tag":True, "scientific_name":True, "common_name":True, "is_reference" : True, "assembly": {"name", "accession_id"}, "type": True})
             response_data = responses.JSONResponse(response_dict, status_code=200)
         else:
-            not_found_response = {"message": "Could not find details for {}".format(slug)}
+            not_found_response = {"message": "Could not explain {}".format(slug)}
             response_data = responses.JSONResponse(not_found_response, status_code=404)
     except Exception as ex:
         logger.log("DEBUG", ex)

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -110,19 +110,22 @@ async def get_genome_details(request: Request, genome_uuid: str):
 
 @router.get("/genome/{slug}/explain", name="genome_explain")
 async def explain_genome(request: Request, slug: str):
-    genome_uuid = grpc_client.get_genome_uuid_from_slug(slug)
+    uuid_from_tag = grpc_client.get_genome_uuid_from_tag(slug)
     response_dict = {}
     response_data = None
-    if genome_uuid:
-        try:
-            genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
-            if genome_details_dict:
-                genome_details = GenomeDetails(**genome_details_dict)
-                response_dict = genome_details.model_dump(include={"genome_id":True, "genome_tag":True, "scientific_name":True, "common_name":True, "is_reference" : True, "assembly": {"name", "accession_id"}, "type": True})
-                response_data = responses.JSONResponse(response_dict, status_code=200)
-            else:
-                not_found_response = {"message": "Could not find details for {}".format(slug)}
-                response_data = responses.JSONResponse(not_found_response, status_code=404)
-        except Exception as ex:
-            logger.log("DEBUG", ex)
+    if uuid_from_tag:
+        genome_detail_for_genome = uuid_from_tag
+    else:
+        genome_detail_for_genome = slug
+    try:
+        genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_detail_for_genome))
+        if genome_details_dict:
+            genome_details = GenomeDetails(**genome_details_dict)
+            response_dict = genome_details.model_dump(include={"genome_id":True, "genome_tag":True, "scientific_name":True, "common_name":True, "is_reference" : True, "assembly": {"name", "accession_id"}, "type": True})
+            response_data = responses.JSONResponse(response_dict, status_code=200)
+        else:
+            not_found_response = {"message": "Could not find details for {}".format(slug)}
+            response_data = responses.JSONResponse(not_found_response, status_code=404)
+    except Exception as ex:
+        logger.log("DEBUG", ex)
     return response_data


### PR DESCRIPTION
### Issue
Requesting explain endpoint 
- with slug works
    - https://staging-2020.ensembl.org/api/metadata/genome/grch38/explain
       ```
       curl http://localhost:8014/api/metadata/genome/grch38/explain | jq 
       {
       "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3",
       "genome_tag": "grch38",
        "common_name": "human",
        "scientific_name": "Homo sapiens",
        "type": null,
        "is_reference": true,
        "assembly": {
             "accession_id": "GCA_000001405.29",
             "name": "GRCh38.p14"
              }
       }
       ```
- with genome_uuid doesn't return anything
    - https://staging-2020.ensembl.org/api/metadata/genome/b29f62e6-992e-4049-a26b-b6bd673c51e7/explain
       ```
       curl http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/explain | jq 
        {}
       ```
  
### Solution

The explain endpoint should accept slug or genome_uuid. 

The fix will 
1) consider the input as slug
2) Try to find out genome_uuid for the slug
    a) if slug has genome_uuid then return the genome_uuid
    b) if slug has no genome_uuid consider input as genome_uuid
3) get genome details for the genome_uuid
4) prepare response and return

### Example
Request based on slug

```
curl http://localhost:8014/api/metadata/genome/grch38/explain | jq
{
  "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3",
  "genome_tag": "grch38",
  "common_name": "human",
  "scientific_name": "Homo sapiens",
  "type": null,
  "is_reference": true,
  "assembly": {
    "accession_id": "GCA_000001405.29",
    "name": "GRCh38.p14"
  }
}
```

Request based on genome_uuid

```
curl http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/explain | jq
{
  "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3",
  "genome_tag": "grch38",
  "common_name": "human",
  "scientific_name": "Homo sapiens",
  "type": null,
  "is_reference": true,
  "assembly": {
    "accession_id": "GCA_000001405.29",
    "name": "GRCh38.p14"
  }
}
```
If it doesn't exist
```
curl -sSD/dev/stderr 'http://localhost:8014/api/metadata/genome/just-kidding/explain' | jq
HTTP/1.1 404 Not Found
date: Tue, 31 Oct 2023 14:45:48 GMT
server: uvicorn
content-length: 53
content-type: application/json

{
  "message": "Could not  explain just-kidding"
}
``` 

for details endpoint
```
curl -sSD/dev/stderr 'http://localhost:8014/api/metadata/genome/just-kidding/details' | jq
HTTP/1.1 404 Not Found
date: Tue, 31 Oct 2023 16:11:40 GMT
server: uvicorn
content-length: 47
content-type: application/json

{
  "message": "Could not find details for just-kidding"
}
```