### PR TITLE
Add regulation stats

### DIFF
--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -14,7 +14,9 @@ class Homology(BaseModel):
 class Regulation(BaseModel):
     enhancers: int = Field(alias="regulation.enhancer_count", default=None)
     promoters: int = Field(alias="regulation.promoter_count", default=None)
-
+    ctcf_count: int = Field(alias="regulation.ctcf_count", default=None)
+    tfbs_count: int = Field(alias="regulation.tfbs_count", default=None)
+    open_chromatin_count: int = Field(alias="regulation.open_chromatin_count", default=None)
 
 class Pseudogene(BaseModel):
     pseudogenes: int = Field(alias="genebuild.ps_pseudogenes", default=None)


### PR DESCRIPTION
### Description
Added following regulation stats

-  ctcf_count
-  tfbs_count
-  open_chromatin_count

### Example
```
curl 'http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/stats' | jq '.["genome_stats"]["regulation_stats"]'
{
  "enhancers": 268483,
  "promoters": 36597,
  "ctcf_count": 101734,
  "tfbs_count": 30873,
  "open_chromatin_count": 110623
}
```

### JIRA
[ENSWBSITES-2233](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2233)