### PR TITLE
Update grpc to 0.0.6a and related refactoring

### DIFF
--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -73,10 +73,10 @@ class GenomeDetails(BaseModel):
             }
         if data.get("attributesInfo", {}).get('AssemblyProviderName', None):
             data["assembly_provider"] = {
-                "name": data.get("attributesInfo", {}).get("AssemblyProviderName", None),
-                "url": data.get("attributesInfo", {}).get("AssemblyProviderUrl", None),
+                "name": data.get("attributesInfo", {}).get("assemblyProviderName", None),
+                "url": data.get("attributesInfo", {}).get("assemblyProviderUrl", None),
             }
-        if data.get("attributesInfo", {}).get('annotationProviderName', None):
+        if data.get("attributesInfo", {}).get('genebuildProviderName', None):
             data["annotation_provider"] = {
                 "name": data.get("attributesInfo", {}).get("genebuildProviderName", None),
                 "url": data.get("attributesInfo", {}).get("genebuildProviderUrl", None),

--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -18,6 +18,7 @@ class Regulation(BaseModel):
     tfbs_count: int = Field(alias="regulation.tfbs_count", default=None)
     open_chromatin_count: int = Field(alias="regulation.open_chromatin_count", default=None)
 
+
 class Pseudogene(BaseModel):
     pseudogenes: int = Field(alias="genebuild.ps_pseudogenes", default=None)
     average_genomic_span: float = Field(alias="genebuild.ps_average_genomic_span", default=None)
@@ -157,22 +158,15 @@ class ExampleObjectList(BaseModel):
         values["example_objects"] = extracted_example_objects
         return values
 
-    def extract_example_objects(genome_attribute_list):
+    def extract_example_objects(genome_attributes):
         extracted_example_objects = []
         try:
-            for genome_attribute in genome_attribute_list:
-                try:
-                    if genome_attribute["name"] == "genebuild.sample_gene":
-                        example_gene = ExampleObject(type="gene", id=genome_attribute["statisticValue"])
-                        extracted_example_objects.append(example_gene)
-                    if genome_attribute["name"] == "genebuild.sample_location":
-                        example_location = ExampleObject(type="location", id=genome_attribute["statisticValue"])
-                        extracted_example_objects.append(example_location)
-                    if genome_attribute["name"] == "variation.sample_variant":
-                        example_variant = ExampleObject(type="variant", id=genome_attribute["statisticValue"])
-                        extracted_example_objects.append(example_variant)
-                except KeyError as ke:
-                    logger.debug(genome_attribute["name"], ke)
+            example_gene = ExampleObject(type="gene", id=genome_attributes["genebuildSampleGene"])
+            extracted_example_objects.append(example_gene)
+            example_location = ExampleObject(type="location", id=genome_attributes["genebuildSampleLocation"])
+            extracted_example_objects.append(example_location)
+            example_variant = ExampleObject(type="variant", id=genome_attributes["variationSampleVariant"])
+            extracted_example_objects.append(example_variant)
         except Exception as ex:
-            logger.debug("Error : ",ex)
+            logger.debug(ex)
         return extracted_example_objects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.5.0
 anyio==3.7.1
 click==8.1.7
-ensembl-metadata-service @ git+https://github.com/Ensembl/ensembl-metadata-service.git@0.0.6a5
+ensembl-metadata-service @ git+https://github.com/Ensembl/ensembl-metadata-service.git@0.0.6a6
 exceptiongroup==1.1.3
 fastapi==0.103.1
 grpcio==1.38.1


### PR DESCRIPTION
### Description
This PR

- Update gRPC version to 0.0.6a6
- With update to 0.0.6a6 the example objects are now available in getGenomeByUUID procedure
- Update example_object to get examples from getGenomeByUUID procedure that iterating over stats endpoint
- Fix issue with annotation provider

### Example

#### Example_objects
```
curl 'http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/example_objects' | jq
[
  {
    "type": "gene",
    "id": "ENSG00000221914"
  },
  {
    "type": "location",
    "id": "8:26291508-26372680"
  }
]
```
#### Annotation Provider Fix
On Staging it is null 
```
curl 'https://staging-2020.ensembl.org/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/details' | jq '.["annotation_provider"]'

null
```

Fix 

```
curl 'http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/details' | jq '.["annotation_provider"]'

{
  "name": "GENCODE",
  "url": "https://gencodegenes.org"
}

```