### PR TITLE
Update metadata stats spec to include reference species name for Compara

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -396,11 +396,12 @@ components:
           properties:
             coverage:
               type: number
-            coverage_explanation:
+            reference_species_name:
               type: string
+              description: Scientific name of the species against which homology was calculated
           required:
             - coverage
-            - coverage_explanation
+            - reference_species_name
           additionalProperties: false
         variation_stats:
           properties:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -399,6 +399,7 @@ components:
             reference_species_name:
               type: string
               description: Scientific name of the species against which homology was calculated
+              example: Homo sapiens
           required:
             - coverage
             - reference_species_name


### PR DESCRIPTION
## Description
In order to be able to show, on the species page, which species homology data has been calculated against (see https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2288), metadata api will need to include this information in the stats payload.

## Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2316
