### PR TITLE
Relax requirements to species stats response

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -214,22 +214,30 @@ components:
           properties:
             contig_n50:
               type: number
+              nullable: true
             total_genome_length:
               type: number
+              nullable: true
             total_coding_sequence_length:
               type: number
+              nullable: true
             total_gap_length:
               type: number
+              nullable: true
             spanned_gaps:
               type: number
+              nullable: true
             chromosomes:
               type: number
             toplevel_sequences:
               type: number
+              nullable: true
             component_sequences:
               type: number
+              nullable: true
             gc_percentage:
               type: number
+              nullable: true
           required:
             - contig_n50
             - total_genome_length
@@ -248,38 +256,55 @@ components:
               type: number
             average_genomic_span:
               type: number
+              nullable: true
             average_sequence_length:
               type: number
+              nullable: true
             average_cds_length:
               type: number
+              nullable: true
             shortest_gene_length:
               type: number
+              nullable: true
             longest_gene_length:
               type: number
+              nullable: true
             total_transcripts:
               type: number
+              nullable: true
             coding_transcripts:
               type: number
+              nullable: true
             transcripts_per_gene:
               type: number
+              nullable: true
             coding_transcripts_per_gene:
               type: number
+              nullable: true
             total_exons:
               type: number
+              nullable: true
             total_coding_exons:
               type: number
+              nullable: true
             average_exon_length:
               type: number
+              nullable: true
             average_coding_exon_length:
               type: number
+              nullable: true
             average_exons_per_transcript:
               type: number
+              nullable: true
             average_coding_exons_per_coding_transcript:
               type: number
+              nullable: true
             total_introns:
               type: number
+              nullable: true
             average_intron_length:
               type: number
+              nullable: true
           required:
             - coding_genes
             - average_genomic_span
@@ -307,32 +332,46 @@ components:
               type: number
             small_non_coding_genes:
               type: number
+              nullable: true
             long_non_coding_genes:
               type: number
+              nullable: true
             misc_non_coding_genes:
               type: number
+              nullable: true
             average_genomic_span:
               type: number
+              nullable: true
             average_sequence_length:
               type: number
+              nullable: true
             shortest_gene_length:
               type: number
+              nullable: true
             longest_gene_length:
               type: number
+              nullable: true
             total_transcripts:
               type: number
+              nullable: true
             transcripts_per_gene:
               type: number
+              nullable: true
             total_exons:
               type: number
+              nullable: true
             average_exon_length:
               type: number
+              nullable: true
             average_exons_per_transcript:
               type: number
+              nullable: true
             total_introns:
               type: number
+              nullable: true
             average_intron_length:
               type: number
+              nullable: true
           required:
             - non_coding_genes
             - small_non_coding_genes
@@ -357,26 +396,37 @@ components:
               type: number
             average_genomic_span:
               type: number
+              nullable: true
             average_sequence_length:
               type: number
+              nullable: true
             shortest_gene_length:
               type: number
+              nullable: true
             longest_gene_length:
               type: number
+              nullable: true
             total_transcripts:
               type: number
+              nullable: true
             transcripts_per_gene:
               type: number
+              nullable: true
             total_exons:
               type: number
+              nullable: true
             average_exon_length:
               type: number
+              nullable: true
             average_exons_per_transcript:
               type: number
+              nullable: true
             total_introns:
               type: number
+              nullable: true
             average_intron_length:
               type: number
+              nullable: true
           required:
             - pseudogenes
             - average_genomic_span

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -229,6 +229,7 @@ components:
               nullable: true
             chromosomes:
               type: number
+              nullable: true
             toplevel_sequences:
               type: number
               nullable: true
@@ -254,6 +255,7 @@ components:
           properties:
             coding_genes:
               type: number
+              nullable: true
             average_genomic_span:
               type: number
               nullable: true
@@ -330,6 +332,7 @@ components:
           properties:
             non_coding_genes:
               type: number
+              nullable: true
             small_non_coding_genes:
               type: number
               nullable: true
@@ -394,6 +397,7 @@ components:
           properties:
             pseudogenes:
               type: number
+              nullable: true
             average_genomic_span:
               type: number
               nullable: true
@@ -450,6 +454,7 @@ components:
               type: string
               description: Scientific name of the species against which homology was calculated
               example: Homo sapiens
+              nullable: true
           required:
             - coverage
             - reference_species_name
@@ -458,16 +463,22 @@ components:
           properties:
             short_variants:
               type: number
+              nullable: true
             structural_variants:
               type: number
+              nullable: true
             short_variants_with_phenotype_assertions:
               type: number
+              nullable: true
             short_variants_with_publications:
               type: number
+              nullable: true
             short_variants_frequency_studies:
               type: number
+              nullable: true
             structural_variants_with_phenotype_assertions:
               type: number
+              nullable: true
           required:
             - short_variants
             - structural_variants
@@ -482,8 +493,10 @@ components:
           properties:
             enhancers:
               type: number
+              nullable: true
             promoters:
               type: number
+              nullable: true
             open_chromatin_count:
               type: number
               nullable: true


### PR DESCRIPTION
## Description
We are relaxing requirements for the statistics payload, making most fields nullable, because appropriate statistics have not been calculated for some of the genomes.

After a discussion at a code review meeting, we decided the following:
- Any field of the statistics payload is allowed to be nullable. The client will try to make sense of it all.
- It is the responsibility of the backend to sanitise the payload. I.e. there shouldn't be any `"NULL"` or `"NA"` strings in the payload to represent missing data (@ens-st3 says all `"NULL"` strings have been removed from the database)
- There is no longer any need to nullify the whole section (i.e. no need to make `variation_stats` or `regulation_stats` be null.

## Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2213