### PR TITLE
Updated script to use view instead of hard coded query.

### DIFF
--- a/species-search-dump/dump_species_search_data_from_metadata.py
+++ b/species-search-dump/dump_species_search_data_from_metadata.py
@@ -17,7 +17,7 @@ class Species(DefaultOnNoneModel):
     id: str = Field(alias="genome_uuid")
     common_name: str = Field(alias="common_name", default="")
     scientific_name: str = Field(alias="scientific_name")
-    assembly: str = Field(alias="assembly_default")
+    assembly: str = Field(alias="assembly_name")
     assembly_accession: str = Field(alias="accession")
     unversioned_assembly_accession: str = Field(alias="accession")
     type_value: str = Field(alias="strain", default="")
@@ -27,8 +27,8 @@ class Species(DefaultOnNoneModel):
     n50: str = Field(alias="contig_n50", default="0")
     has_variation: bool = Field(default=False)
     has_regulation: bool = Field(default=False)
-    annotation_method: str = Field(alias="genebuild_method", default="")
-    annotation_provider: str = Field(alias="annotation_provider", default="")
+    annotation_method: str = Field(alias="genebuild_method")
+    annotation_provider: str = Field(alias="genebuild_provider")
     
     #New fields
     genome_uuid:str
@@ -110,57 +110,29 @@ def dump_species():
     
     mycursor = mydb.cursor()
     
-    query = """
-    select distinct g.genome_uuid,
-    o.common_name,
-    o.scientific_name,
-    o.strain_type,
-    o.strain,
-    a.assembly_default,
-    a.accession,
-    a.url_name ,
-    a.tol_id,
-    a.is_reference,
-    a.name,
-    o.species_taxonomy_id,
-    o.scientific_parlance_name,
-    o.organism_id,
-    o.rank,
-    stats.contig_n50                                   as contig_n50,
-    stats.coding_genes                                 as coding_genes,
-    datasets.has_variation,
-    datasets.has_regulation,
-    ifnull(nullif(stats.provider_name, ''), 'Ensembl') as annotation_provider,
-    stats.genebuild_method                             as genebuild_method
-    from genome g
-        join organism o using (organism_id)
-        join assembly a using (assembly_id)
-        left join organism_group_member ogm using (organism_id)
-        left join organism_group og on (ogm.organism_group_id = og.organism_group_id and og.code = 'population')
-        join (select g.genome_id,
-                    max(case when a.name = 'assembly.provider_name' then da.value else null end)   as provider_name,
-                    max(case when a.name = 'genebuild.method_display' then da.value else null end) as genebuild_method,
-                    max(case when a.name = 'genebuild.coding_genes' then da.value else null end)   as coding_genes,
-                    max(case when a.name = 'assembly.contig_n50' then da.value else null end)      as contig_n50#)
-            from dataset_attribute da
-                    join attribute a on da.attribute_id = a.attribute_id
-                    join dataset d on da.dataset_id = d.dataset_id
-                    join genome_dataset gd on gd.dataset_id = d.dataset_id
-                    join genome g on g.genome_id = gd.genome_id
-            where a.name in ('assembly.provider_name', 'genebuild.method_display', 'genebuild.coding_genes',
-                            'assembly.contig_n50')
-            group by g.genome_uuid) as stats on g.genome_id = stats.genome_id
-        left join (select g.genome_id,
-                        max(case when dt.name = 'regulation_build' then 1 else 0 end) as has_regulation,
-                        max(case when dt.name = 'variation' then 1 else 0 end)       as has_variation
-                from genome g
-                            left join genome_dataset gd on gd.genome_id = g.genome_id
-                            join dataset d on d.dataset_id = gd.dataset_id
-                            join dataset_type dt on d.dataset_type_id = dt.dataset_type_id
-                where dt.name in ('regulation_build', 'variation')) as datasets
-                on datasets.genome_id = g.genome_id
-    order by a.assembly_default, o.rank, o.ensembl_name, a.assembly_id, g.genome_uuid;
-    """
+    query = """SELECT 
+    genome_uuid,
+    common_name,
+    scientific_name,
+    strain_type,
+    strain,
+    assembly_name,
+    accession,
+    url_name,
+    tol_id,
+    is_reference,
+    name,
+    species_taxonomy_id,
+    scientific_parlance_name,
+    organism_id,
+    rank,
+    contig_n50,
+    coding_genes,
+    has_variation,
+    has_regulation,
+    genebuild_provider,
+    genebuild_method
+    from genome_search"""
     
     mycursor.execute(query)
     columns = [desc[0] for desc in mycursor.description]
@@ -172,9 +144,12 @@ def dump_species():
         try:
             sd = Species(**dict_row)
             species_data.append(sd)
+
         except ValidationError as err:
             print(f"Unable to validate {dict_row['scientific_name']}")
             print(f"Errors found {err.error_count()}")
+            for e in err.errors():
+                print(f"{e['type']}: {e['loc']}")
     
     species_list = SpeciesList(
     species_list=species_data,
@@ -185,7 +160,7 @@ def dump_species():
     
     print(f"Total : {len(species_data)}")
     
-    with open("ensemblnext_species_v4.json", "w") as sddf:
+    with open("ensemblnext_species.json", "w") as sddf:
         sddf.write(species_list.model_dump_json())
     
 if __name__ == "__main__": 


### PR DESCRIPTION
This PR is to update the script to use a production owned view instead of the large SQL string. 
It also has the following changes

- removes default value for annotation_provider and annotation_method
- moves annotation_provider to use genbuild_provider to match changes in the database. 
- Improves validation error reporting
- Switches from default assembly to assembly name