### PR TITLE
Add an openAPI spec for the region endpoint

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -111,6 +111,29 @@ paths:
         404:
           description: Genome not found
           content: {}
+  /api/metadata/genome/{genome_id}/regions/{region_id}:
+    get:
+      summary: Returns brief information about a genomic region
+      parameters:
+      - name: genome_id
+        in: path
+        required: true
+        schema:
+          type: string
+          example: 3704ceb1-948d-11ec-a39d-005056b38ce3
+      - name: region_id
+        in: path
+        required: true
+        schema:
+          type: string
+          example: "13"
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopLevelRegion'
   /api/metadata/validate_location:
     get:
       summary: Checks validity of genomic location provided by user


### PR DESCRIPTION
## Description
Add openAPI spec describing an endpoint that sends back a brief summary about a genomic region. Will allow us to support genome browser navigation to a full genomic region provided with region name only ([ENSWBSITES-2256](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2256)).

expected payload in the response, if we reuse the `TopLevelRegion` schema:

```
{
  "name": "1",
  "type": "chromosome",
  "length": 248956422,
  "is_circular": false
}
```

## Questions
- `regions` or `region` (endpoint naming conventions)?
- `regions` or `top_level_regions`?
- The proposed payload reuses the same `TopLevelRegion` schema as the karyotype endpoint. Will this be sufficient? Can we assume that we will only ever need to fetch data about regions that start at `1`?
- Consider [this XD](https://xd.adobe.com/view/a924144e-f983-4638-b3cb-96ad4099828d-fc77/?fullscreen). What data, and in which endpoints, do we need to provide to the client so that it can know that:
  - An assembly has both a karyotype and unassembled regions ([XD](https://xd.adobe.com/view/a924144e-f983-4638-b3cb-96ad4099828d-fc77/screen/525f32ec-f81b-455f-9449-5bd904a3b30f?fullscreen))
  - An assembly consists of primary assemblies ([XD](https://xd.adobe.com/view/a924144e-f983-4638-b3cb-96ad4099828d-fc77/screen/97b40e7c-07dd-4d97-976a-2199db413d38?fullscreen))
  - An assembly consists only of unassembled regions ([XD](https://xd.adobe.com/view/a924144e-f983-4638-b3cb-96ad4099828d-fc77/screen/a6a51a28-ff7d-4e6f-a220-edd697287b4a?fullscreen))

Jira ticket:
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2318