### PR TITLE
Homology ref species

### DIFF
--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -1,5 +1,5 @@
 import logging
-from pydantic import BaseModel, Field, validator, field_serializer, root_validator
+from pydantic import BaseModel, Field, validator, field_serializer, root_validator, AliasChoices
 from typing import List
 from core.logging import InterceptHandler
 
@@ -7,15 +7,15 @@ logging.getLogger().handlers = [InterceptHandler()]
 from loguru import logger
 
 class Homology(BaseModel):
-    coverage: float = Field(alias="compara.homology_coverage ", default=None)
-    reference_species_name: str = Field(alias="compara.homology_reference_species ", default=None)
+    coverage: float = Field(alias=AliasChoices("compara.homology_coverage","compara.homology_coverage "), default=None)
+    reference_species_name: str = Field(alias=AliasChoices("compara.homology_reference_species", "compara.homology_reference_species "), default=None)
 
     @validator('reference_species_name', pre=True)
     def validate_na_values(cls, v ) -> str:
-        rsn = ""
+        sanitized_reference_species_name = ""
         if v:
-            rsn = v
-        return rsn
+            sanitized_reference_species_name = v
+        return sanitized_reference_species_name
 
     @field_serializer('reference_species_name')
     def serialize_refernce_species(self, value: str):

--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -7,9 +7,21 @@ logging.getLogger().handlers = [InterceptHandler()]
 from loguru import logger
 
 class Homology(BaseModel):
-    coverage: float = Field(alias="homology_coverage", default=None)
-    coverage_explanation: str = None
+    coverage: float = Field(alias="compara.homology_coverage ", default=None)
+    reference_species_name: str = Field(alias="compara.homology_reference_species ", default=None)
 
+    @validator('reference_species_name', pre=True)
+    def validate_na_values(cls, v ) -> str:
+        rsn = ""
+        if v:
+            rsn = v
+        return rsn
+
+    @field_serializer('reference_species_name')
+    def serialize_refernce_species(self, value: str):
+        if value == "":
+            return None
+        return value
 
 class Regulation(BaseModel):
     enhancers: int = Field(alias="regulation.enhancer_count", default=None)


### PR DESCRIPTION
## Description

Add homology reference_species to stats endpoint.

## Related JIRA
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2317

## Examples

### Example 1 - reference_species
```
curl  'http://localhost:8014/api/metadata/genome/1cda6f4c-8f49-4305-b435-5cbe00adec9a/stats'  | jq '.["genome_stats"]["homology_stats"]' 
{
  "coverage": 40.7,
  "reference_species_name": "Triticum turgidum subsp. durum"
}
```

### Example 2 - reference_species
```
curl 'http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/stats' | jq '.["genome_stats"]["homology_stats"]'    
{
  "coverage": 91.6,
  "reference_species_name": "Pan troglodytes"
}

```
### Example 3 - null
(Spoofed the stats in order to produce this)
```
curl "http://localhost:8014/api/metadata/genome/${gid}/stats" | jq '.["genome_stats"]["homology_stats"]'
{
  "coverage": null,
  "reference_species_name": null
}


```
