### PR TITLE
Handle server error

### DIFF
--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -131,6 +131,7 @@ async def get_genome_details(request: Request, genome_uuid: str):
             response_data = responses.JSONResponse(not_found_response, status_code=404)
     except Exception as ex:
         logger.debug(ex)
+        return response_error_handler({"status": 500})
     return response_data
 
 @router.get("/genome/{slug}/explain", name="genome_explain")
@@ -149,4 +150,5 @@ async def explain_genome(request: Request, slug: str):
             response_data = responses.JSONResponse(response_dict, status_code=200)
     except Exception as ex:
         logger.debug(ex)
+        return response_error_handler({"status": 500})
     return response_data

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -139,15 +139,15 @@ async def explain_genome(request: Request, slug: str):
     response_dict = {}
     not_found_response = {"message": "Could not explain {}".format(slug)}
     response_data = responses.JSONResponse(not_found_response, status_code=404)
-    genome_uuid = grpc_client.get_genome_uuid_from_tag(slug)
-    if not genome_uuid:
-        genome_uuid = slug
     try:
-        genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
-        if genome_details_dict:
-            genome_details = GenomeDetails(**genome_details_dict)
-            response_dict = genome_details.model_dump(include={"genome_id":True, "genome_tag":True, "scientific_name":True, "species_taxonomy_id": True, "common_name":True, "is_reference" : True, "assembly": {"name", "accession_id"}, "type": True})
-            response_data = responses.JSONResponse(response_dict, status_code=200)
+        genome_uuid = grpc_client.get_genome_uuid_from_tag(slug)
+        if not genome_uuid:
+            genome_uuid = slug
+            genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
+            if genome_details_dict:
+                genome_details = GenomeDetails(**genome_details_dict)
+                response_dict = genome_details.model_dump(include={"genome_id":True, "genome_tag":True, "scientific_name":True, "species_taxonomy_id": True, "common_name":True, "is_reference" : True, "assembly": {"name", "accession_id"}, "type": True})
+                response_data = responses.JSONResponse(response_dict, status_code=200)
     except Exception as ex:
         logger.debug(ex)
         return response_error_handler({"status": 500})


### PR DESCRIPTION
## Description

Send 500 status code when there is a server error. Currently it sends 404 which is misleading.

## Related JIRA
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2336


## Examples
In order to produce this Stop grpc Service and try following endpoints

### /explain - Server Error

```
$ curl 'http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/explain' 
{"status_code": 500, "details": "Internal Server Error"}%                                                                                                                                                                              
```

### /details - Server Error
```
$ curl 'http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/details' 
{"status_code": 500, "details": "Internal Server Error"}
```