### PR TITLE
Update image-url & grpc version

### DIFF
--- a/app/api/models/popular_species.py
+++ b/app/api/models/popular_species.py
@@ -25,7 +25,7 @@ class PopularSpecies(BaseModel):
 
     @validator('image', pre=True)
     def generate_image_url(cls, v ) -> str:
-        return '{}static/genome_images/{}.svg'.format(cls._base_url, v)
+        return '//{}/static/genome_images/{}.svg'.format(cls._base_url, v)
 
     @validator("species_taxonomy_id", pre=True)
     def concert_int_to_str(cls, value):

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -73,7 +73,7 @@ async def get_popular_species(request: Request):
     try:
         popular_species_dict = MessageToDict(grpc_client.get_popular_species())
         popular_species = popular_species_dict['organismsGroupCount']
-        popular_species_response = PopularSpeciesGroup(_base_url=request.base_url, popular_species=popular_species)
+        popular_species_response = PopularSpeciesGroup(_base_url=request.headers["host"], popular_species=popular_species)
         return responses.JSONResponse(popular_species_response.dict())
     except Exception as e:
         logger.debug(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.5.0
 anyio==3.7.1
 click==8.1.7
-ensembl-metadata-service @ git+https://github.com/Ensembl/ensembl-metadata-service.git@0.0.7dev1
+ensembl-metadata-service @ git+https://github.com/Ensembl/ensembl-metadata-service.git@0.0.7.dev1
 exceptiongroup==1.1.3
 fastapi==0.103.1
 grpcio==1.38.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.5.0
 anyio==3.7.1
 click==8.1.7
-ensembl-metadata-service @ git+https://github.com/Ensembl/ensembl-metadata-service.git@0.0.6
+ensembl-metadata-service @ git+https://github.com/Ensembl/ensembl-metadata-service.git@0.0.7dev1
 exceptiongroup==1.1.3
 fastapi==0.103.1
 grpcio==1.38.1


### PR DESCRIPTION
## Introduction
This PR

1. Update Image URL in the popular_species endpoint 
2. Update grpc version to 0.0.7dev1

## Description

### Current  response

```
 curl 'https://beta.ensembl.org/api/metadata/popular_species' | jq '.["popular_species"][0]'
  
{
  "species_taxonomy_id": "9606",
  "name": "human",
  "image": "http://beta.ensembl.org/static/genome_images/9606.svg",
  "genomes_count": 99
}

```

### With the changes 
```
curl 'https://staging-2020.ensembl.org/api/metadata/popular_species' | jq '.["popular_species"][0]'
{
  "species_taxonomy_id": "9606",
  "name": "human",
  "image": "//staging-2020.ensembl.org/static/genome_images/9606.svg",
  "genomes_count": 99
}
```

## JIRA

https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2343

