### PR TITLE
Update ensembl-metadata-service to 0.0.7.dev2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.5.0
 anyio==3.7.1
 click==8.1.7
-ensembl-metadata-service @ git+https://github.com/Ensembl/ensembl-metadata-service.git@0.0.7.dev1
+ensembl-metadata-service @ git+https://github.com/Ensembl/ensembl-metadata-service.git@0.0.7.dev2
 exceptiongroup==1.1.3
 fastapi==0.103.1
 grpcio==1.38.1


### PR DESCRIPTION
Update ensembl-metadata-service to 0.0.7.dev2, so that it could handle a renamed database field (`ensembl_name` was renamed to `biosample_id`).

