### PR TITLE
Upgrade metadata grpc dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # Base image
-FROM python:3.9.6
+FROM python:3.11
 
 # Maintainer
 LABEL org.opencontainers.image.authors="ensembl-webteam@ebi.ac.uk"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 annotated-types==0.5.0
 anyio==3.7.1
 click==8.1.7
-ensembl-metadata-service @ git+https://github.com/Ensembl/ensembl-metadata-service.git@0.0.7.dev2
-exceptiongroup==1.1.3
+ensembl-metadata-api @ git+https://github.com/Ensembl/ensembl-metadata-api.git@2.0.0.dev2
+exceptiongroup==1.2.0
 fastapi==0.103.1
-grpcio==1.38.1
-grpcio-tools==1.38.1
+grpcio==1.60.0
+grpcio-tools==1.60.0
 h11==0.14.0
-idna==3.4
+idna==3.6
 loguru==0.7.2
-protobuf==3.20.0
+protobuf==4.25.2
 pydantic==2.4.1
 pydantic_core==2.10.1
 six==1.16.0


### PR DESCRIPTION
- Upgrade to python 3.11.
- Upgrade dependencies required by metadata api.
- Move from metadata service to metadata API.