### PR TITLE
Add API spec for FTP links and region checksums

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -111,6 +111,55 @@ paths:
         404:
           description: Genome not found
           content: {}
+  /api/metadata/genome/{genome_id}/ftplinks:
+    get:
+      summary: Returns a list of FTP download links for the specified genome
+      parameters:
+      - name: genome_id
+        in: path
+        required: true
+        schema:
+          type: string
+          example: 3704ceb1-948d-11ec-a39d-005056b38ce3
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FTPLink'
+        404:
+          description: Genome not found
+          content: {}
+  /api/metadata/genome/{genome_id}/checksum/{region_id}:
+    get:
+      summary: Returns a checksum for the specified top-level region
+      parameters:
+        - name: genome_id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 3704ceb1-948d-11ec-a39d-005056b38ce3
+        - name: region_id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "13"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                example: 428d56c3fc01ad3a8db49830fb587625
+        404:
+          description: Region not found
+          content: {}
   /api/metadata/validate_location:
     get:
       summary: Checks validity of genomic location provided by user
@@ -777,3 +826,23 @@ components:
             (Note that if we support other region formats in user input, such as UCSC region name,
             then the region segment of the location string will be normalised to Ensembl region names,
             e.g. instead of chr13:32272495-32442859, it will say 13:32272495-32442859.)
+    FTPLink:
+      type: object
+      properties:
+        dataset:
+          type: string
+          enum:
+            - genebuild
+            - assembly
+            - homologies
+            - regulation
+            - variation
+        url:
+          type: string
+          example: https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/Homo_sapiens/GCA_000001405.29/ensembl/genome
+      required:
+        - dataset
+        - url
+      additionalProperties: false
+      description: FTP link to a dataset directory for a genome
+            

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -153,7 +153,7 @@ paths:
         200:
           description: Successful operation
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
                 example: 428d56c3fc01ad3a8db49830fb587625


### PR DESCRIPTION
Update API spec to include new endpoints:
* For fetching FTP file links for a specified genome ([JIRA](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2279))
* For fetching the ckecksum for a specified top-level region in a genome ([JIRA](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2403))

JIRA: 
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2429
- https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2423

Examples in the spec:
FTP links:
```
Request: .../api/metadata/genome/3704ceb1-948d-11ec-a39d-005056b38ce3/ftplinks
Response:
[
  {
    "dataset": "genebuild",
    "url": "https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/Homo_sapiens/GCA_000001405.29/ensembl/genome"
  },
  { 
    "dataset": "variation",
    "url": ...
  },
  ...
]
```
Checksums:
```
Request: .../api/metadata/genome/3704ceb1-948d-11ec-a39d-005056b38ce3/checksum/13
Response:
428d56c3fc01ad3a8db49830fb587625
```