### PR TITLE
Add FTP links endpoint

### DIFF
--- a/app/api/models/ftplinks.py
+++ b/app/api/models/ftplinks.py
@@ -14,6 +14,7 @@
 
 from pydantic import BaseModel, Field, HttpUrl, field_serializer
 from typing import Literal
+from core.config import FTP_BASE_URL
 
 class FTPLink(BaseModel):
     dataset: Literal['genebuild', 'assembly', 'homologies',
@@ -22,7 +23,7 @@ class FTPLink(BaseModel):
     
     @field_serializer('url')
     def url_serializer(self, path: str) -> HttpUrl:
-        return f"https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/{path}"
+        return f"{FTP_BASE_URL}{path}"
 
 class FTPLinks(BaseModel):
     links: list[FTPLink] = Field(..., validation_alias='Links')

--- a/app/api/models/ftplinks.py
+++ b/app/api/models/ftplinks.py
@@ -1,0 +1,28 @@
+"""
+    See the NOTICE file distributed with this work for additional information
+    regarding copyright ownership.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+from pydantic import BaseModel, Field, HttpUrl, field_serializer
+from typing import Literal
+
+class FTPLink(BaseModel):
+    dataset: Literal['genebuild', 'assembly', 'homologies',
+                     'regulation', 'variation'] = Field(..., validation_alias='datasetType')
+    url: str = Field(..., validation_alias='path')
+    
+    @field_serializer('url')
+    def url_serializer(self, path: str) -> HttpUrl:
+        return f"https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/{path}"
+
+class FTPLinks(BaseModel):
+    links: list[FTPLink] = Field(..., validation_alias='Links')

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -91,3 +91,7 @@ class GRPCClient:
         if genome_uuid_data.genome_uuid:
             return genome_uuid_data.genome_uuid
         return None
+    
+    def get_ftplinks(self, genome_uuid: str):
+        ftp_links_request = ensembl_metadata_pb2.FTPLinksRequest(genome_uuid=genome_uuid, dataset_type="all")
+        return self.stub.GetFTPLinks(ftp_links_request)

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -24,6 +24,7 @@ from api.models.statistics import GenomeStatistics, ExampleObjectList
 from api.models.popular_species import PopularSpeciesGroup
 from api.models.karyotype import Karyotype
 from api.models.genome import GenomeDetails
+from api.models.ftplinks import FTPLinks
 
 from core.config import GRPC_HOST, GRPC_PORT
 from core.logging import InterceptHandler
@@ -146,6 +147,15 @@ async def get_genome_details(request: Request, genome_uuid: str):
         return response_error_handler({"status": 500})
     return response_data
 
+@router.get("/genome/{genome_uuid}/ftplinks", name="genome_ftplinks")
+async def get_genome_ftplinks(request: Request, genome_uuid: str):
+    try:
+        ftplinks_dict = MessageToDict(grpc_client.get_ftplinks(genome_uuid))
+        ftplinks = FTPLinks(**ftplinks_dict)
+        return responses.JSONResponse(ftplinks.dict().get("links", []))
+    except Exception as ex:
+        logger.debug(ex)
+        return response_error_handler({"status": 500})
 
 @router.get("/genome/{slug}/explain", name="genome_explain")
 async def explain_genome(request: Request, slug: str):

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -46,6 +46,11 @@ ENA_ASSEMBLY_URL: str = config(
     "ENA_ASSEMBLY_URL", default="https://www.ebi.ac.uk/ena/browser/view/"
 )
 
+# Base URL for FTP download links
+FTP_BASE_URL: str = config(
+    "FTP_BASE_URL", default="https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/"
+)
+
 # logging configuration
 LOGGING_LEVEL = logging.DEBUG if DEBUG else logging.INFO
 LOGGERS = ("uvicorn.asgi", "uvicorn.access")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.5.0
 anyio==3.7.1
 click==8.1.7
-ensembl-metadata-api @ git+https://github.com/Ensembl/ensembl-metadata-api.git@2.0.0.dev2
+ensembl-metadata-api @ git+https://github.com/Ensembl/ensembl-metadata-api.git@2.0.0.dev3
 exceptiongroup==1.2.0
 fastapi==0.103.1
 grpcio==1.60.0


### PR DESCRIPTION
This PR implements Metadata REST API endpoint for fetching FTP download links for a genome.
Maintenance moved to a [separate PR](https://github.com/Ensembl/ensembl-web-metadata-api/pull/43).

JIRA: https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2430

Test on local machine (grpc service from k8s staging):
`http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/ftplinks`
```
[
  {
    "dataset": "variation",
    "url": "https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/Homo_sapiens/GCA_000001405.29/ensembl/variation/GENCODE44"
  },
  {
    "dataset": "regulation",
    "url": "https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/Homo_sapiens/GCA_000001405.29/ensembl/regulation"
  },
  {
    "dataset": "homologies",
    "url": "https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/Homo_sapiens/GCA_000001405.29/ensembl/homology/GENCODE44"
  },
  {
    "dataset": "assembly",
    "url": "https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/Homo_sapiens/GCA_000001405.29/ensembl/genome"
  },
  {
    "dataset": "genebuild",
    "url": "https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/Homo_sapiens/GCA_000001405.29/ensembl/genebuild/GENCODE44"
  }
]
```