### PR TITLE
Maintenance

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -25,11 +25,15 @@ paths:
             default: grch38
       responses:
         '200':
-          description: successful operation
+          description: Successful operation
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BriefGenomeDetails'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /api/metadata/genome/{genome_id}/stats:
     get:
       tags:
@@ -45,7 +49,7 @@ paths:
             default: a7335667-93e7-11ec-a39d-005056b38ce3
       responses:
         '200':
-          description: successful operation
+          description: Successful operation
           content:
             application/json:
               schema:
@@ -53,6 +57,8 @@ paths:
                 properties:
                   genome_stats:
                     $ref: '#/components/schemas/GenomeStats'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /api/metadata/genome/{genome_id}/details:
     get:
       tags:
@@ -67,11 +73,23 @@ paths:
             default: a7335667-93e7-11ec-a39d-005056b38ce3
       responses:
         '200':
-          description: successful operation
+          description: Successful operation
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenomeDetails'
+        '404':
+          description: Genome not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Could not find details for a7335667-93e7-11ec-a39d-005056b38ce3"
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /api/metadata/genome/{genome_id}/example_objects:
     get:
       description: Returns a list of example objects (gene, variant, location, etc.) for a genome.
@@ -91,6 +109,18 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ExampleObject'
+        '404':
+          description: Genome not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Could not find for a7335667-93e7-11ec-a39d-005056b38ce3"
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /api/metadata/genome/{genome_id}/karyotype:
     get:
       summary: Returns a list of top-level regions included in the organism's karyotype
@@ -102,15 +132,14 @@ paths:
           type: string
           example: 3704ceb1-948d-11ec-a39d-005056b38ce3
       responses:
-        200:
+        '200':
           description: successful operation
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Karyotype'
-        404:
-          description: Genome not found
-          content: {}
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /api/metadata/genome/{genome_id}/ftplinks:
     get:
       summary: Returns a list of FTP download links for the specified genome
@@ -122,7 +151,7 @@ paths:
           type: string
           example: 3704ceb1-948d-11ec-a39d-005056b38ce3
       responses:
-        200:
+        '200':
           description: Successful operation
           content:
             application/json:
@@ -130,9 +159,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FTPLink'
-        404:
-          description: Genome not found
-          content: {}
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /api/metadata/genome/{genome_id}/checksum/{region_id}:
     get:
       summary: Returns a checksum for the specified top-level region
@@ -150,16 +178,18 @@ paths:
             type: string
             example: "13"
       responses:
-        200:
+        '200':
           description: Successful operation
           content:
             text/plain:
               schema:
                 type: string
                 example: 428d56c3fc01ad3a8db49830fb587625
-        404:
+        '404':
           description: Region not found
           content: {}
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /api/metadata/validate_location:
     get:
       summary: Checks validity of genomic location provided by user
@@ -178,23 +208,14 @@ paths:
           type: string
           example: 1:10000-1000000
       responses:
-        200:
+        '200':
           description: location validation information (location can be either valid or invalid)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/LocationValidationResponse'
-        400:
-          description: bad input; for example due to parsing error
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: object
-                    example:
-                      parse: "Could not parse location 13 32,442,859-32,272,495"
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /api/metadata/popular_species:
     get:
       tags:
@@ -212,6 +233,8 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/PopularSpecies'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
 
 components:
   schemas:
@@ -845,4 +868,20 @@ components:
         - url
       additionalProperties: false
       description: FTP link to a dataset directory for a genome
+  responses:
+    404NotFound:
+      description: The scpecified resource was not found
+      content:
+        text/plain:
+          schema:
+            type: string
+            example: '{"status_code": 404, "details": "Not Found"}'
+    500InternalServerError:
+      description: Internal server error
+      content:
+        text/plain:
+          schema:
+            type: string
+            example: '{"status_code": 500, "details": "Internal Server Error"}'
+
             

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -118,7 +118,7 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: "Could not find for a7335667-93e7-11ec-a39d-005056b38ce3"
+                    example: "Could not find example objects for a7335667-93e7-11ec-a39d-005056b38ce3"
         '500':
           $ref: '#/components/responses/500InternalServerError'
   /api/metadata/genome/{genome_id}/karyotype:
@@ -870,7 +870,7 @@ components:
       description: FTP link to a dataset directory for a genome
   responses:
     404NotFound:
-      description: The scpecified resource was not found
+      description: The specified resource was not found
       content:
         text/plain:
           schema:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Metadata API for new Ensembl website (https://beta.ensembl.org)
 git clone https://github.com/Ensembl/ensembl-web-metadata-api
 cd ensembl-web-metadata-api
 vi .env #add values for PORT, GRPC_HOST, GRPC_PORT
-source .env
 docker-compose -f docker-compose.yml up
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 Metadata API for new Ensembl website (https://beta.ensembl.org)
 
 ### Deploy the app and run docker-compose:
-```
-$ git clone https://github.com/Ensembl/ensembl-web-metadata-api
-$ cd ensembl-web-metadata-api
-$ docker-compose -f docker-compose.yml up
+```bash
+git clone https://github.com/Ensembl/ensembl-web-metadata-api
+cd ensembl-web-metadata-api
+vi .env #add values for PORT, GRPC_HOST, GRPC_PORT
+source .env
+docker-compose -f docker-compose.yml up
 ```
 
 ### Run unit tests:
-```
-$ docker-compose -f docker-compose.yml run metadata_api python -m unittest
+```bash
+docker-compose -f docker-compose.yml run metadata_api python -m unittest
 ```
  

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Ensembl Web Metadata API
-Metadata API for new-website (2020.ensembl.org)
+Metadata API for new Ensembl website (https://beta.ensembl.org)
 
 ### Deploy the app and run docker-compose:
- 
- `$ git clone https://github.com/Ensembl/ensembl-web-metadata-api.git`
- `$  cd ensembl-web-metadata-api`
- `$  docker-compose -f docker-compose.yml up`
+```
+$ git clone https://github.com/Ensembl/ensembl-web-metadata-api
+$ cd ensembl-web-metadata-api
+$ docker-compose -f docker-compose.yml up
+```
+
 ### Run unit tests:
-`$ docker-compose -f docker-compose.yml run metadata_api python -m unittest`
+```
+$ docker-compose -f docker-compose.yml run metadata_api python -m unittest
+```
  

--- a/app/api/models/karyotype.py
+++ b/app/api/models/karyotype.py
@@ -12,8 +12,7 @@
    limitations under the License.
 """
 
-from pydantic import BaseModel, Field, AliasChoices, validator
-from typing import List, Dict, Any, ClassVar
+from pydantic import BaseModel, Field
 
 
 class Region(BaseModel):
@@ -24,4 +23,4 @@ class Region(BaseModel):
 
 
 class Karyotype(BaseModel):
-    top_level_regions: List[Region]
+    top_level_regions: list[Region]

--- a/app/api/models/popular_species.py
+++ b/app/api/models/popular_species.py
@@ -13,7 +13,7 @@
 """
 
 from pydantic import BaseModel, Field, AliasChoices, validator
-from typing import List, Dict, Any, ClassVar
+from typing import ClassVar
 
 
 class PopularSpecies(BaseModel):
@@ -37,7 +37,7 @@ class PopularSpecies(BaseModel):
 
 class PopularSpeciesGroup(BaseModel):
     _base_url: str
-    popular_species: List[PopularSpecies]
+    popular_species: list[PopularSpecies]
 
     def __init__(self, **data):
         PopularSpecies._base_url = data["_base_url"]

--- a/app/api/models/region_validation.py
+++ b/app/api/models/region_validation.py
@@ -13,7 +13,7 @@
 """
 
 from pydantic import BaseModel, model_serializer, Field, root_validator
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 from loguru import logger
 from core.config import GRPC_HOST, GRPC_PORT
 from api.resources.grpc_client import GRPCClient
@@ -28,7 +28,7 @@ class RegionValidation(BaseModel):
     start: int = Field(alias="start", default=1)
     end: Optional[int] = Field(alias="end", default=None)
     _region_code: str = None
-    _is_valid: [bool, bool, bool] = [False, False, False]
+    _is_valid: list[bool] = [False, False, False]
     _region_name_error: str = None
     _start_error: str = None
     _end_error: str = None
@@ -102,7 +102,7 @@ class RegionValidation(BaseModel):
         return False
 
     @model_serializer
-    def region_validation_serliaiser(self) -> Dict[str, Any]:
+    def region_validation_serliaiser(self) -> dict[str, Any]:
         serialized_region = {
             "region": {"error_code": None, "error_message": None},
             "start": {"error_code": None, "error_message": None},

--- a/app/api/models/statistics.py
+++ b/app/api/models/statistics.py
@@ -7,7 +7,6 @@ from pydantic import (
     root_validator,
     AliasChoices,
 )
-from typing import List
 from core.logging import InterceptHandler
 
 logging.getLogger().handlers = [InterceptHandler()]
@@ -250,7 +249,7 @@ class ExampleObject(BaseModel):
 
 
 class ExampleObjectList(BaseModel):
-    example_objects: List[ExampleObject] = []
+    example_objects: list[ExampleObject] = []
 
     @root_validator(pre=True)
     def set_region_parameters(cls, values):

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -106,7 +106,7 @@ def example_objects(request: Request, genome_id: str):
                 example_objects.dict()["example_objects"]
             )
         else:
-            not_found_response = {"message": "Could not find for {}".format(genome_id)}
+            not_found_response = {"message": "Could not find example objects for {}".format(genome_id)}
             response_data = responses.JSONResponse(not_found_response, status_code=404)
     except Exception as ex:
         logger.debug(ex)

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -47,7 +47,7 @@ async def get_metadata_statistics(request: Request, genome_uuid: str):
     try:
         top_level_stats_dict = MessageToDict(grpc_client.get_statistics(genome_uuid))
         genome_stats = GenomeStatistics(_raw_data=top_level_stats_dict["statistics"])
-        return responses.JSONResponse({"genome_stats": genome_stats.dict()})
+        return responses.JSONResponse({"genome_stats": genome_stats.model_dump()})
     except Exception as e:
         logger.debug(e)
         return response_error_handler({"status": 500})
@@ -63,7 +63,7 @@ async def get_genome_karyotype(request: Request, genome_uuid: str):
             for tlr in top_level_regions:
                 tlr["is_circular"] = True
         karyotype_response = Karyotype(top_level_regions=top_level_regions)
-        return responses.JSONResponse(karyotype_response.dict()["top_level_regions"])
+        return responses.JSONResponse(karyotype_response.model_dump()["top_level_regions"])
     except Exception as e:
         logger.debug(e)
         return response_error_handler({"status": 500})
@@ -77,7 +77,7 @@ async def get_popular_species(request: Request):
         popular_species_response = PopularSpeciesGroup(
             _base_url=request.headers["host"], popular_species=popular_species
         )
-        return responses.JSONResponse(popular_species_response.dict())
+        return responses.JSONResponse(popular_species_response.model_dump())
     except Exception as e:
         logger.debug(e)
         return response_error_handler({"status": 500})
@@ -88,7 +88,7 @@ def validate_region(request: Request, genome_id: str, location: str):
     try:
         rgv = RegionValidation(genome_uuid=genome_id, location_input=location)
         rgv.validate_region()
-        return responses.JSONResponse(rgv.dict())
+        return responses.JSONResponse(rgv.model_dump())
     except Exception as e:
         logger.debug(e)
         return response_error_handler({"status": 500})
@@ -103,7 +103,7 @@ def example_objects(request: Request, genome_id: str):
                 example_objects=genome_details_dict["attributesInfo"]
             )
             response_data = responses.JSONResponse(
-                example_objects.dict()["example_objects"]
+                example_objects.model_dump()["example_objects"]
             )
         else:
             not_found_response = {"message": "Could not find example objects for {}".format(genome_id)}
@@ -124,7 +124,7 @@ async def get_genome_details(request: Request, genome_uuid: str):
         genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
         if genome_details_dict:
             genome_details = GenomeDetails(**genome_details_dict)
-            response_data = responses.JSONResponse(genome_details.dict())
+            response_data = responses.JSONResponse(genome_details.model_dump())
         else:
             not_found_response = {
                 "message": "Could not find details for {}".format(genome_uuid)
@@ -140,7 +140,7 @@ async def get_genome_ftplinks(request: Request, genome_uuid: str):
     try:
         ftplinks_dict = MessageToDict(grpc_client.get_ftplinks(genome_uuid))
         ftplinks = FTPLinks(**ftplinks_dict)
-        return responses.JSONResponse(ftplinks.dict().get("links", []))
+        return responses.JSONResponse(ftplinks.model_dump().get("links", []))
     except Exception as ex:
         logger.debug(ex)
         return response_error_handler({"status": 500})

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -94,18 +94,6 @@ def validate_region(request: Request, genome_id: str, location: str):
         return response_error_handler({"status": 500})
 
 
-@router.get("/genome/{genome_id}/region/{region_name}", name="region_info")
-def get_region_info(request: Request, genome_id: str, region_name: str):
-    try:
-        location_input = "{}:0-0".format(region_name)
-        rgv = RegionValidation(genome_uuid=genome_id, location_input=location_input)
-        rgv.get_region_info(region_name)
-        return responses.JSONResponse(rgv.model_dump())
-    except Exception as e:
-        logger.debug(e)
-        return response_error_handler({"status": 500})
-
-
 @router.get("/genome/{genome_id}/example_objects", name="example_objects")
 def example_objects(request: Request, genome_id: str):
     try:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,7 +17,6 @@ limitations under the License.
 
 import logging
 import sys
-from typing import List
 
 from loguru import logger
 from starlette.config import Config
@@ -31,7 +30,7 @@ API_PREFIX = "/api"
 config = Config(".env")
 DEBUG: bool = config("DEBUG", cast=bool, default=False)
 PROJECT_NAME: str = config("PROJECT_NAME", default="Ensembl Web Metadata API")
-ALLOWED_HOSTS: List[str] = config(
+ALLOWED_HOSTS: list[str] = config(
     "ALLOWED_HOSTS",
     cast=CommaSeparatedStrings,
     default="*",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.5.0
 anyio==3.7.1
 click==8.1.7
-ensembl-metadata-api @ git+https://github.com/Ensembl/ensembl-metadata-api.git@2.0.0.dev2
+ensembl-metadata-api @ git+https://github.com/Ensembl/ensembl-metadata-api.git@2.0.0.dev3
 exceptiongroup==1.2.0
 fastapi==0.103.1
 grpcio==1.60.0

--- a/species-search-dump/dump_species_search_data.py
+++ b/species-search-dump/dump_species_search_data.py
@@ -1,8 +1,6 @@
 import mysql.connector
-from pydantic import BaseModel, Field, model_serializer, FieldValidationInfo, ValidationError, field_validator
-from typing import List, Dict, Any
-import json
-from json import JSONEncoder
+from pydantic import BaseModel, Field, model_serializer, ValidationError, field_validator
+from typing import Any
 
 
 class Species(BaseModel):
@@ -23,7 +21,7 @@ class Species(BaseModel):
     annotation_provider: str = Field(alias="annotation.provider_name", default=None)
 
     @model_serializer
-    def serialise_species_model(self) -> Dict[str, Any]:
+    def serialise_species_model(self) -> dict[str, Any]:
         species_json = [
             {"name": field_name, "value": field_value}
             for field_name, field_value in self
@@ -38,14 +36,14 @@ class Species(BaseModel):
         return v
 
 class SpeciesList(BaseModel):
-    species_list: List[Species]
+    species_list: list[Species]
     name: str
     release: str
     # release_date: str
     entry_count: int
 
     @model_serializer
-    def ser_model(self) -> Dict[str, Any]:
+    def ser_model(self) -> dict[str, Any]:
         species_search_data = {}
         species_search_data["name"] = self.name
         species_search_data["release"] = self.release

--- a/species-search-dump/dump_species_search_data_from_metadata.py
+++ b/species-search-dump/dump_species_search_data_from_metadata.py
@@ -1,11 +1,9 @@
-from typing import List, Dict, Any
-from json import JSONEncoder
-import json
+from typing import Any
 import sys
 import configparser
 
 import mysql.connector
-from pydantic import BaseModel, Field, model_serializer, FieldValidationInfo, ValidationError, field_validator, model_validator
+from pydantic import BaseModel, Field, model_serializer, ValidationError, field_validator, model_validator
 
 class DefaultOnNoneModel(BaseModel):
     def __init__(self, **data):
@@ -40,7 +38,7 @@ class Species(DefaultOnNoneModel):
     rank:int = Field(default="0")
     
     @model_serializer
-    def serialise_species_model(self) -> Dict[str, Any]:
+    def serialise_species_model(self) -> dict[str, Any]:
         species_json = [
             {"name": field_name, "value": field_value}
             for field_name, field_value in self
@@ -64,14 +62,14 @@ class Species(DefaultOnNoneModel):
         return self
 
 class SpeciesList(BaseModel):
-    species_list: List[Species]
+    species_list: list[Species]
     name: str
     release: str
     # release_date: str
     entry_count: int
 
     @model_serializer
-    def ser_model(self) -> Dict[str, Any]:
+    def ser_model(self) -> dict[str, Any]:
         species_search_data = {}
         species_search_data["name"] = self.name
         species_search_data["release"] = self.release


### PR DESCRIPTION
Non-functional cleanup/maintenance:
* Updated API spec to reflect the current endpoint implementation
* Updated type hints (for pyton 3.8+) and deprecated `.dict()` calls
* Removed unused imports and one endpoint
* Updated README

See related conversation in the [parent PR](https://github.com/Ensembl/ensembl-web-metadata-api/pull/42).