### PR TITLE
REST API that accepts the name of a top-level region and returns its sequence checksum.

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -133,7 +133,7 @@ paths:
         404:
           description: Genome not found
           content: {}
-  /api/metadata/genome/{genome_id}/checksum/{region_id}:
+  /api/metadata/genome/{genome_id}/checksum/{region_name}:
     get:
       summary: Returns a checksum for the specified top-level region
       parameters:
@@ -143,7 +143,7 @@ paths:
           schema:
             type: string
             example: 3704ceb1-948d-11ec-a39d-005056b38ce3
-        - name: region_id
+        - name: region_name
           in: path
           required: true
           schema:

--- a/app/api/models/checksums.py
+++ b/app/api/models/checksums.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel, Field
+
+
+class Checksum(BaseModel):
+    md5: str = Field(max_length=32)

--- a/app/api/models/checksums.py
+++ b/app/api/models/checksums.py
@@ -2,4 +2,4 @@ from pydantic import BaseModel, Field
 
 
 class Checksum(BaseModel):
-    md5: str = Field(max_length=32)
+    md5: str = Field(min_length=32, max_length=32)

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -95,3 +95,7 @@ class GRPCClient:
     def get_ftplinks(self, genome_uuid: str):
         ftp_links_request = ensembl_metadata_pb2.FTPLinksRequest(genome_uuid=genome_uuid, dataset_type="all")
         return self.stub.GetFTPLinks(ftp_links_request)
+
+    def get_region_checksum(self, genome_uuid: str, region_name: str):
+        region_checksum = ensembl_metadata_pb2.GenomeAssemblySequenceRegionRequest(genome_uuid=genome_uuid, sequence_region_name=region_name)
+        return self.stub.GetGenomeAssemblySequenceRegion(region_checksum)

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 
 from fastapi import APIRouter, Request, responses
-from loguru import logger:
+from loguru import logger
 from pydantic import ValidationError
 
 from api.error_response import response_error_handler

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -17,9 +17,11 @@ limitations under the License.
 import logging
 
 from fastapi import APIRouter, Request, responses
-from loguru import logger
+from loguru import logger:
+from pydantic import ValidationError
 
 from api.error_response import response_error_handler
+from api.models.checksums import Checksum
 from api.models.statistics import GenomeStatistics, ExampleObjectList
 from api.models.popular_species import PopularSpeciesGroup
 from api.models.karyotype import Karyotype
@@ -147,6 +149,7 @@ async def get_genome_details(request: Request, genome_uuid: str):
         return response_error_handler({"status": 500})
     return response_data
 
+
 @router.get("/genome/{genome_uuid}/ftplinks", name="genome_ftplinks")
 async def get_genome_ftplinks(request: Request, genome_uuid: str):
     try:
@@ -156,6 +159,7 @@ async def get_genome_ftplinks(request: Request, genome_uuid: str):
     except Exception as ex:
         logger.debug(ex)
         return response_error_handler({"status": 500})
+
 
 @router.get("/genome/{slug}/explain", name="genome_explain")
 async def explain_genome(request: Request, slug: str):
@@ -186,3 +190,18 @@ async def explain_genome(request: Request, slug: str):
         logger.debug(ex)
         return response_error_handler({"status": 500})
     return response_data
+
+
+@router.get("/genome/{genome_uuid}/checksum/{region_name}", name="region_checksum")
+async def get_genome_ftplinks(request: Request, genome_uuid: str, region_name: str):
+    try:
+        region_checksum_dict = MessageToDict(grpc_client.get_region_checksum(genome_uuid=genome_uuid, region_name=region_name))
+        region_checksum = Checksum(**region_checksum_dict)
+        return responses.PlainTextResponse(region_checksum.md5)
+    except ValidationError as e:
+        error_type = e.errors()[0]['type']
+        if error_type.index('missing') == 0:
+            return response_error_handler({"status": 404})
+    except Exception as ex:
+        logger.debug(ex)
+        return response_error_handler({"status": 500})


### PR DESCRIPTION
Add an endpoint to the metadata REST API that accepts the name of a top-level region and returns its sequence checksum.
Jira: [ENSWBSITES-2403](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2403)