### PR TITLE
Implemented server reflection in GRPCClient

### DIFF
--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -13,14 +13,8 @@
 """
 
 import grpc
-from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.json_format import MessageToDict
-import grpc
-from google.protobuf.message_factory import MessageFactory
-from grpc_reflection.v1alpha.proto_reflection_descriptor_database import ProtoReflectionDescriptorDatabase
 from yagrc import reflector as yagrc_reflector
-
-from loguru import logger
 
 
 class GRPCClient:

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -51,7 +51,7 @@ async def get_metadata_statistics(request: Request, genome_uuid: str):
         genome_stats = GenomeStatistics(_raw_data=top_level_stats_dict["statistics"])
         return responses.JSONResponse({"genome_stats": genome_stats.dict()})
     except Exception as e:
-        logger.debug(e)
+        logger.exception(e)
         return response_error_handler({"status": 500})
 
 

--- a/app/tests/test_core/test_grpc_connection.py
+++ b/app/tests/test_core/test_grpc_connection.py
@@ -19,13 +19,13 @@ genome_uuid = "a7335667-93e7-11ec-a39d-005056b38ce3"
 print("connecting to gRPC server on ", GRPC_HOST, ":", GRPC_PORT)
 gc = GRPCClient(GRPC_HOST, GRPC_PORT)
 
-genome_info = gc.get_genome(genome_uuid)
+genome_info = gc.get_genome_details(genome_uuid)
 genome_as_json = MessageToJson(genome_info)
 print(genome_as_json)
 
 top_level_stats = gc.get_statistics(genome_uuid)
 top_level_stats_dict = MessageToDict(top_level_stats)
 print(top_level_stats_dict)
-
-karyotype_data = gc.get_karyotype(genome_uuid)
-print (karyotype_data)
+# TODO see if still a method to call
+# karyotype_data = gc.get_karyotype(genome_uuid)
+# print (karyotype_data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ sniffio==1.3.0
 starlette==0.27.0
 typing_extensions==4.8.0
 uvicorn==0.23.2
+yagrc==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 annotated-types==0.5.0
 anyio==3.7.1
 click==8.1.7
-ensembl-metadata-api @ git+https://github.com/Ensembl/ensembl-metadata-api.git@2.0.0.dev5
 exceptiongroup==1.2.0
 fastapi==0.103.1
 grpcio==1.60.0


### PR DESCRIPTION
Implemented reflection usage to avoid hard dependency with ensembl-metadata-api package version. 
Use reflection instead. 