### PR TITLE
Support GCA/GCF URLs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,4 +2,4 @@ PORT=8014
 DEBUG=False
 GRPC_HOST=ensembl-metadata-service.ensembl-dev
 GRPC_PORT=50051
-ASSEMBLY_URLS=https://identifiers.org/
+IDENTIFIERS_ORG_BASE_URL=https://identifiers.org/

--- a/.env.sample
+++ b/.env.sample
@@ -2,4 +2,4 @@ PORT=8014
 DEBUG=False
 GRPC_HOST=ensembl-metadata-service.ensembl-dev
 GRPC_PORT=50051
-ENA_ASSEMBLY_URL=https://www.ebi.ac.uk/ena/browser/view/
+ASSEMBLY_URLS=https://identifiers.org/

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -602,7 +602,7 @@ components:
           example: HG02559.alt.pat.f1_v2
         url:
           type: string
-          example: https://www.ebi.ac.uk/ena/browser/view/GCA_018466855.1
+          example: https://identifiers.org/insdc.gca/GCA_018466855.1
           nullable: true
       required:
         - accession_id

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -11,7 +11,7 @@ from pydantic import (
 )
 
 from core.logging import InterceptHandler
-from core.config import ENA_ASSEMBLY_URL
+from core.config import ASSEMBLY_URLS
 
 logging.getLogger().handlers = [InterceptHandler()]
 from loguru import logger
@@ -35,8 +35,10 @@ class AssemblyInGenome(BaseModel):
 
     @validator("url", always=True)
     def generate_url(cls, value):
-        if value and "GCA" in value:
-            return ENA_ASSEMBLY_URL + value
+        if value.startswith("GCA"):
+            return ASSEMBLY_URLS['GCA'] + value
+        if value.startswith("GCF"):
+            return ASSEMBLY_URLS['GCF'] + value
         return None
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -41,7 +41,7 @@ ALLOWED_HOSTS: List[str] = config(
 GRPC_HOST: str = config("GRPC_HOST", default="localhost")
 GRPC_PORT: int = config("GRPC_PORT", default=50051)
 
-# ENA URL
+# IDENTIFIERS_ORG URL
 IDENTIFIERS_ORG_BASE_URL: str = config(
     "IDENTIFIERS_ORG_BASE_URL", default="https://identifiers.org/"
 )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -42,9 +42,14 @@ GRPC_HOST: str = config("GRPC_HOST", default="localhost")
 GRPC_PORT: int = config("GRPC_PORT", default=50051)
 
 # ENA URL
-ENA_ASSEMBLY_URL: str = config(
-    "ENA_ASSEMBLY_URL", default="https://www.ebi.ac.uk/ena/browser/view/"
+IDENTIFIERS_ORG_BASE_URL: str = config(
+    "IDENTIFIERS_ORG_BASE_URL", default="https://identifiers.org/"
 )
+
+ASSEMBLY_URLS = {}
+
+ASSEMBLY_URLS['GCA'] = IDENTIFIERS_ORG_BASE_URL + "insdc.gca/"
+ASSEMBLY_URLS['GCF'] = IDENTIFIERS_ORG_BASE_URL + "refseq.gcf/"
 
 # Base URL for FTP download links
 FTP_BASE_URL: str = config(


### PR DESCRIPTION
## Problem 

MVP will have assemblies tagged as both GCA and GCF, and both the species table and the species pages will need to have links to ENA and NCBI respectively.

## Description
The PR uses resolver services https://identifiers.irg to provide URLs for assembly.

## JIRA
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2257

## Example

```
$ curl 'http://localhost:8014/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/details' | jq '.["assembly"]' 
{
  "accession_id": "GCA_000001405.29",
  "name": "GRCh38.p14",
  "url": "https://identifiers.org/insdc.gca/GCA_000001405.29"
}

```
## Review App URL
No available

## Note
This requires change in the environment variable. Instead of ENA_ASSEMBLY_URL it will need IDENTIFIERS_ORG_BASE_URL. 
Before merging this to main please merge the PR in new-api-config 
### Related PRs
#### Search Hub
To make it consistent across all API
https://gitlab.ebi.ac.uk/ensembl-web/ensembl_search_hub/-/merge_requests/13
 
#### Config Update
To expose IDENTIFIERS_ORG_BASE_URL environment variable
https://gitlab.ebi.ac.uk/ensembl-web/newsite-api-config-setup/-/merge_requests/12