### PR TITLE
Change base ftp url

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -924,7 +924,7 @@ components:
             - variation
         url:
           type: string
-          example: https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/Homo_sapiens/GCA_000001405.29/ensembl/genome
+          example: https://ftp.ebi.ac.uk/pub/ensemblorganisms/Homo_sapiens/GCA_000001405.29/ensembl/genome
       required:
         - dataset
         - url

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -52,7 +52,7 @@ ASSEMBLY_URLS["GCF"] = IDENTIFIERS_ORG_BASE_URL + "refseq.gcf/"
 
 # Base URL for FTP download links
 FTP_BASE_URL: str = config(
-    "FTP_BASE_URL", default="https://ftp.ebi.ac.uk/pub/databases/ensembl/organisms/"
+    "FTP_BASE_URL", default="https://ftp.ebi.ac.uk/pub/ensemblorganisms/"
 )
 
 # logging configuration


### PR DESCRIPTION
### Description
Production has changed the location where they put files for access over ftp.

New base path is: `https://ftp.ebi.ac.uk/pub/ensemblorganisms`

When you combine it with a path returned from from gRPC, for example:

```
    {
      "dataset_type": "assembly",
      "path": "Homo_sapiens/GCA_000001405.29/ensembl/genome"
    },
```

you get: `https://ftp.ebi.ac.uk/pub/ensemblorganisms/Homo_sapiens/GCA_000001405.29/ensembl/genome`, which is a working url.