### PR TITLE
Improve speed by implementing dedicated gRPC calls per endpoint

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -11,13 +11,13 @@ tags:
   - name: api
     description: Ensembl Web Metadata API
 paths:
-  /api/metadata/genome/{slug}/explain:
+  /api/metadata/genome/{genome_id_or_slug}/explain:
     get:
       description: Satisfies client's need to disambiguate a string that is part of url pathname
         and that can be either a genome id, or a genome tag. Genome ids are used to communicate
-        whth Ensembl apis; but genome tag only serves the purpose of keeping the url pretty and stable.
+        with Ensembl apis; but genome tag only serves the purpose of keeping the url pretty and stable.
       parameters:
-        - name: slug
+        - name: genome_id_or_slug
           in: path
           required: true
           schema:

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -63,7 +63,7 @@ class AnnotationProvider(BaseModel):
         return url
 
 
-class BriefGenomeDetails(BaseModel):
+class BaseGenomeDetails(BaseModel):
     genome_id: str = Field(alias="genomeUuid")
     genome_tag: Optional[str] = Field(
         alias=AliasChoices(
@@ -80,7 +80,16 @@ class BriefGenomeDetails(BaseModel):
     assembly: AssemblyInGenome = None
 
 
-class GenomeDetails(BriefGenomeDetails):
+class BriefGenomeDetails(BaseGenomeDetails):
+    """
+    As mentioned in this PR: https://github.com/Ensembl/ensembl-web-metadata-api/pull/60
+    We're planning to extend the BriefGenomeDetails class later but for now,
+    we will leave it as an empty extension of BaseGenomeDetails
+    """
+    pass
+
+
+class GenomeDetails(BaseGenomeDetails):
     taxonomy_id: str = Field(alias=AliasPath("organism", "taxonomyId"))
     species_taxonomy_id: str = Field(alias=AliasPath("organism", "speciesTaxonomyId"))
     assembly_provider: AssemblyProvider = None

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -63,7 +63,7 @@ class AnnotationProvider(BaseModel):
         return url
 
 
-class GenomeDetails(BaseModel):
+class BriefGenomeDetails(BaseModel):
     genome_id: str = Field(alias="genomeUuid")
     genome_tag: Optional[str] = Field(
         alias=AliasChoices(
@@ -71,8 +71,6 @@ class GenomeDetails(BaseModel):
         ),
         default=None,
     )
-    taxonomy_id: str = Field(alias=AliasPath("organism", "taxonomyId"))
-    species_taxonomy_id: str = Field(alias=AliasPath("organism", "speciesTaxonomyId"))
     common_name: str = Field(alias=AliasPath("organism", "commonName"), default=None)
     scientific_name: str = Field(alias=AliasPath("organism", "scientificName"))
     type: Optional[Type] = None
@@ -80,6 +78,11 @@ class GenomeDetails(BaseModel):
         alias=AliasPath("assembly", "isReference"), default=False
     )
     assembly: AssemblyInGenome = None
+
+
+class GenomeDetails(BriefGenomeDetails):
+    taxonomy_id: str = Field(alias=AliasPath("organism", "taxonomyId"))
+    species_taxonomy_id: str = Field(alias=AliasPath("organism", "speciesTaxonomyId"))
     assembly_provider: AssemblyProvider = None
     assembly_level: str = Field(alias=AliasPath("attributesInfo", "assemblyLevel"))
     assembly_date: str = Field(

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -60,12 +60,12 @@ class GRPCClient:
 
         return response
 
-    def get_brief_genome_details(self, genome_uuid: str):
+    def get_brief_genome_details(self, genome_uuid_or_slug: str):
         # Create request
         request_class = self.reflector.message_class(
             "ensembl_metadata.GenomeUUIDRequest"
         )
-        request = request_class(genome_uuid=genome_uuid)
+        request = request_class(genome_uuid=genome_uuid_or_slug)
 
         # Get response
         response = self.stub.GetBriefGenomeDetailsByUUID(request)

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -48,12 +48,12 @@ class GRPCClient:
         toplevel_stats_by_uuid = self.stub.GetTopLevelStatisticsByUUID(genome_request)
         return toplevel_stats_by_uuid
 
-    def get_genome_details(self, genome_uuid: str):
+    def get_genome_details(self, genome_uuid: str, get_attributes: bool = True):
         # Create request
         request_class = self.reflector.message_class(
             "ensembl_metadata.GenomeUUIDRequest"
         )
-        request = request_class(genome_uuid=genome_uuid)
+        request = request_class(genome_uuid=genome_uuid, get_attributes=get_attributes)
 
         # Get response
         response = self.stub.GetGenomeByUUID(request)

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -48,15 +48,37 @@ class GRPCClient:
         toplevel_stats_by_uuid = self.stub.GetTopLevelStatisticsByUUID(genome_request)
         return toplevel_stats_by_uuid
 
-    def get_genome_details(self, genome_uuid: str, get_attributes: bool = True):
+    def get_genome_details(self, genome_uuid: str):
         # Create request
         request_class = self.reflector.message_class(
             "ensembl_metadata.GenomeUUIDRequest"
         )
-        request = request_class(genome_uuid=genome_uuid, get_attributes=get_attributes)
+        request = request_class(genome_uuid=genome_uuid)
 
         # Get response
         response = self.stub.GetGenomeByUUID(request)
+
+        return response
+
+    def get_brief_genome_details(self, genome_uuid: str):
+        # Create request
+        request_class = self.reflector.message_class(
+            "ensembl_metadata.GenomeUUIDRequest"
+        )
+        request = request_class(genome_uuid=genome_uuid)
+
+        # Get response
+        response = self.stub.GetBriefGenomeDetailsByUUID(request)
+
+        return response
+
+    def get_attributes_info(self, genome_uuid: str):
+        request_class = self.reflector.message_class(
+            "ensembl_metadata.GenomeUUIDRequest"
+        )
+        request = request_class(genome_uuid=genome_uuid)
+
+        response = self.stub.GetAttributesByGenomeUUID(request)
 
         return response
 
@@ -94,16 +116,6 @@ class GRPCClient:
             genome_seq_region_request
         )
         return genome_seq_region
-
-    def get_genome_uuid_from_tag(self, tag):
-        request_class = self.reflector.message_class(
-            "ensembl_metadata.GenomeTagRequest"
-        )
-        uuid_request = request_class(genome_tag=tag)
-        genome_uuid_data = self.stub.GetGenomeUUIDByTag(uuid_request)
-        if genome_uuid_data.genome_uuid:
-            return genome_uuid_data.genome_uuid
-        return None
 
     def get_ftplinks(self, genome_uuid: str):
         request_class = self.reflector.message_class("ensembl_metadata.FTPLinksRequest")

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -101,10 +101,10 @@ def validate_region(request: Request, genome_id: str, location: str):
 @router.get("/genome/{genome_id}/example_objects", name="example_objects")
 def example_objects(request: Request, genome_id: str):
     try:
-        genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_id))
-        if genome_details_dict:
+        attributes_info = MessageToDict(grpc_client.get_attributes_info(genome_id))
+        if attributes_info:
             example_objects = ExampleObjectList(
-                example_objects=genome_details_dict["attributesInfo"]
+                example_objects=attributes_info
             )
             response_data = responses.JSONResponse(
                 example_objects.model_dump()["example_objects"]
@@ -159,15 +159,12 @@ async def get_genome_ftplinks(request: Request, genome_uuid: str):
         return response_error_handler({"status": 500})
 
 
-@router.get("/genome/{slug}/explain", name="genome_explain")
-async def explain_genome(request: Request, slug: str):
-    not_found_response = {"message": "Could not explain {}".format(slug)}
+@router.get("/genome/{genome_id_or_slug}/explain", name="genome_explain")
+async def explain_genome(request: Request, genome_id_or_slug: str):
+    not_found_response = {"message": "Could not explain {}".format(genome_id_or_slug)}
     response_data = responses.JSONResponse(not_found_response, status_code=404)
     try:
-        genome_uuid = grpc_client.get_genome_uuid_from_tag(slug)
-        if not genome_uuid:
-            genome_uuid = slug
-        genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid, get_attributes=False))
+        genome_details_dict = MessageToDict(grpc_client.get_brief_genome_details(genome_id_or_slug))
         if genome_details_dict:
             genome_details = BriefGenomeDetails(**genome_details_dict)
             response_dict = genome_details.model_dump(

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -104,7 +104,7 @@ def example_objects(request: Request, genome_id: str):
         attributes_info = MessageToDict(grpc_client.get_attributes_info(genome_id))
         if attributes_info:
             example_objects = ExampleObjectList(
-                example_objects=attributes_info
+                example_objects=attributes_info["attributesInfo"]
             )
             response_data = responses.JSONResponse(
                 example_objects.model_dump()["example_objects"]

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -25,7 +25,7 @@ from api.models.checksums import Checksum
 from api.models.statistics import GenomeStatistics, ExampleObjectList
 from api.models.popular_species import PopularSpeciesGroup
 from api.models.karyotype import Karyotype
-from api.models.genome import GenomeDetails, DatasetAttributes
+from api.models.genome import BriefGenomeDetails, GenomeDetails, DatasetAttributes
 from api.models.ftplinks import FTPLinks
 
 from core.config import GRPC_HOST, GRPC_PORT
@@ -167,9 +167,9 @@ async def explain_genome(request: Request, slug: str):
         genome_uuid = grpc_client.get_genome_uuid_from_tag(slug)
         if not genome_uuid:
             genome_uuid = slug
-        genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
+        genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid, get_attributes=False))
         if genome_details_dict:
-            genome_details = GenomeDetails(**genome_details_dict)
+            genome_details = BriefGenomeDetails(**genome_details_dict)
             response_dict = genome_details.model_dump(
                 include={
                     "genome_id": True,


### PR DESCRIPTION
### Related JIRA Ticket
https://www.ebi.ac.uk/panda/jira/browse/EA-1238

### Changes
Improved speed by implementing dedicated gRPC calls per endpoint and updated this repo to reflect the changes.

> Can be tested by using this metadata-api tag: https://github.com/Ensembl/ensembl-metadata-api/releases/tag/3.1.0a1

* Kept using `GetGenomeByUUID` gRPC procedure for `/details` API endpoint
* Added `get_attributes_info()` corresponding to `GetAttributesByGenomeUUID` in gRPC for `/example_objects`
* Added `get_brief_genome_details()` corresponding to `GetBriefGenomeDetailsByUUID` in gRPC for `/explain`
  * Also removed the use of `get_genome_uuid_from_tag()` and embedded the logic in the gRPC call itself

### Related PR
I ended up creating dedicated gRPC calls for `/example_objects` and `/explain` endpoints, you can see the request and response examples in the PR below:
https://github.com/Ensembl/ensembl-metadata-api/pull/109

> ⚠️ I didn't manage to run tests successfully 

Feel free to take over this PR and update/edit it as you see fit
