### PR TITLE
Add new grpc endpoint to get genome id from accession id

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -285,14 +285,14 @@ paths:
           $ref: '#/components/responses/500InternalServerError'
   /api/metadata/genomeid/:
     get:
-      summary: Returns a list of genome uuids and its release version
+      summary: Returns the latest genome object
       parameters:
       - name: assembly_accession_id
         in: query
         required: true
         schema:
           type: string
-          example: GCA_009914755.4
+          example: GCA_000001405.29
       responses:
         '200':
           description: successful operation
@@ -306,18 +306,17 @@ paths:
 components:
   schemas:
     GenomeIDFromAssemblyAccessionResponse:
-      type: array
-      items:
-        $ref: '#/components/schemas/GenomeIDObject'
-    GenomeIdObject:
       type: object
       properties:
         genome_id:
           type: string
-          example: "4c07817b-c7c5-463f-8624-982286bc4355"
+          example: "a7335667-93e7-11ec-a39d-005056b38ce3"
         release_version:
           type: number
           example: "110"
+        genome_tag:
+          type: string
+          example: "grch38"
     BriefGenomeDetails:
       type: object
       properties:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -300,6 +300,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenomeIDFromAssemblyAccessionResponse'
+        '404':
+          $ref: '#/components/responses/404NotFound'
         '500':
           $ref: '#/components/responses/500InternalServerError'
 

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -283,10 +283,41 @@ paths:
                     example: 'Could not find details for genome 0cbc227a-7179-43c2-8061-a50d94423c4d and dataset homologies.'
         '500':
           $ref: '#/components/responses/500InternalServerError'
+  /api/metadata/genomeid/:
+    get:
+      summary: Returns a list of genome uuids and its release version
+      parameters:
+      - name: assembly_accession_id
+        in: query
+        required: true
+        schema:
+          type: string
+          example: GCA_009914755.4
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenomeIDFromAssemblyAccessionResponse'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
 
 components:
   schemas:
-
+    GenomeIDFromAssemblyAccessionResponse:
+      type: array
+      items:
+        $ref: '#/components/schemas/GenomeIDObject'
+    GenomeIdObject:
+      type: object
+      properties:
+        genome_id:
+          type: string
+          example: "4c07817b-c7c5-463f-8624-982286bc4355"
+        release_version:
+          type: number
+          example: "110"
     BriefGenomeDetails:
       type: object
       properties:

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -156,3 +156,7 @@ class DatasetAttribute(BaseModel):
 class DatasetAttributes(BaseModel):
     attributes: list[DatasetAttribute]
     release_version: float = Field(alias="releaseVersion")
+
+class GenomeByKeyword(BaseModel):
+    genome_uuid: str = Field(alias="genomeUuid", default="")
+    release_version: float = Field(alias=AliasPath("release", "releaseVersion"), default=0)

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -160,3 +160,4 @@ class DatasetAttributes(BaseModel):
 class GenomeByKeyword(BaseModel):
     genome_uuid: str = Field(alias="genomeUuid", default="")
     release_version: float = Field(alias=AliasPath("release", "releaseVersion"), default=0)
+    genome_tag: str = Field(alias=AliasPath("assembly", "urlName"), default="")

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -12,6 +12,7 @@
    limitations under the License.
 """
 
+import logging
 import grpc
 from google.protobuf.json_format import MessageToDict
 from yagrc import reflector as yagrc_reflector
@@ -148,3 +149,12 @@ class GRPCClient:
                 genome_uuid=genome_uuid, dataset_type=dataset_type
             )
         return self.stub.GetAttributesValuesByUUID(dataset_attributes)
+
+    def get_genome_by_specific_keyword(self, assembly_accession_id: str):
+        # Create request
+        request_class = self.reflector.message_class(
+            "ensembl_metadata.GenomeBySpecificKeywordRequest"
+        )
+        request = request_class(assembly_accession_id=assembly_accession_id)
+        response = self.stub.GetGenomesBySpecificKeyword(request)
+        return response

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -150,11 +150,10 @@ class GRPCClient:
             )
         return self.stub.GetAttributesValuesByUUID(dataset_attributes)
 
-    def get_genome_by_specific_keyword(self, assembly_accession_id: str):
-        # Create request
+    def get_genome_by_specific_keyword(self, **kwargs):
         request_class = self.reflector.message_class(
             "ensembl_metadata.GenomeBySpecificKeywordRequest"
         )
-        request = request_class(assembly_accession_id=assembly_accession_id)
+        request = request_class(**kwargs)
         response = self.stub.GetGenomesBySpecificKeyword(request)
         return response

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -244,15 +244,13 @@ async def get_genome_dataset_attributes(
 async def get_genome_by_keyword(request: Request, assembly_accession_id: str):
     try:
         genome_response = grpc_client.get_genome_by_specific_keyword(assembly_accession_id=assembly_accession_id)
-        has_genome = False
         latest_genome_by_keyword_object = GenomeByKeyword()
         for arr in genome_response:
-            has_genome = True
             arr = MessageToDict(arr)
             genome_by_keyword_object = GenomeByKeyword(**arr)
             if (genome_by_keyword_object.release_version > latest_genome_by_keyword_object.release_version):
                 latest_genome_by_keyword_object = genome_by_keyword_object
-        if (has_genome):
+        if (latest_genome_by_keyword_object.genome_uuid):
             return latest_genome_by_keyword_object
         else:            
             logging.error(f"Assembly accession id {assembly_accession_id} not found")

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -251,7 +251,7 @@ async def get_genome_by_keyword(request: Request, assembly_accession_id: str):
             if (genome_by_keyword_object.release_version > latest_genome_by_keyword_object.release_version):
                 latest_genome_by_keyword_object = genome_by_keyword_object
         if (latest_genome_by_keyword_object.genome_uuid):
-            return latest_genome_by_keyword_object
+            return responses.JSONResponse(latest_genome_by_keyword_object.model_dump())
         else:            
             logging.error(f"Assembly accession id {assembly_accession_id} not found")
             return response_error_handler({"status": 404})

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -252,10 +252,10 @@ async def get_genome_by_keyword(request: Request, assembly_accession_id: str):
             genome_by_keyword_object = GenomeByKeyword(**arr)
             if (genome_by_keyword_object.release_version > latest_genome_by_keyword_object.release_version):
                 latest_genome_by_keyword_object = genome_by_keyword_object
-
         if (has_genome):
             return latest_genome_by_keyword_object
         else:            
+            logging.error(f"Assembly accession id {assembly_accession_id} not found")
             return response_error_handler({"status": 404})
 
     except Exception as ex:

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -242,18 +242,22 @@ async def get_genome_dataset_attributes(
 
 @router.get("/genomeid")
 async def get_genome_by_keyword(request: Request, assembly_accession_id: str):
-    if (assembly_accession_id == ""):
-        not_found_response = {"message": "missing assembly_accession_id"}
-        return responses.JSONResponse(not_found_response, status_code=404)
     try:
         genome_response = grpc_client.get_genome_by_specific_keyword(assembly_accession_id=assembly_accession_id)
+        has_genome = False
         latest_genome_by_keyword_object = GenomeByKeyword()
         for arr in genome_response:
+            has_genome = True
             arr = MessageToDict(arr)
             genome_by_keyword_object = GenomeByKeyword(**arr)
             if (genome_by_keyword_object.release_version > latest_genome_by_keyword_object.release_version):
                 latest_genome_by_keyword_object = genome_by_keyword_object
-        return latest_genome_by_keyword_object
+
+        if (has_genome):
+            return latest_genome_by_keyword_object
+        else:            
+            return response_error_handler({"status": 404})
+
     except Exception as ex:
         logging.error(ex)
         return response_error_handler({"status": 500})

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -240,7 +240,7 @@ async def get_genome_dataset_attributes(
         logging.error(ex)
         return response_error_handler({"status": 500})
 
-@router.get("/genome")
+@router.get("/genomeid")
 async def get_genome_by_keyword(request: Request, assembly_accession_id: str):
     if (assembly_accession_id == ""):
         not_found_response = {"message": "missing assembly_accession_id"}

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -240,12 +240,15 @@ async def get_genome_dataset_attributes(
         logging.error(ex)
         return response_error_handler({"status": 500})
 
-@router.get("/genomeid/{assembly_accession_id}", name="genome_id")
-async def get_uuid(request: Request, assembly_accession_id: str):
+@router.get("/genome")
+async def get_genome_by_keyword(request: Request, assembly_accession_id: str):
+    if (assembly_accession_id == ""):
+        not_found_response = {"message": "missing assembly_accession_id"}
+        return responses.JSONResponse(not_found_response, status_code=404)
     try:
-        genome_array = grpc_client.get_genome_by_specific_keyword(assembly_accession_id)
+        genome_response = grpc_client.get_genome_by_specific_keyword(assembly_accession_id=assembly_accession_id)
         latest_genome_by_keyword_object = GenomeByKeyword()
-        for arr in genome_array:
+        for arr in genome_response:
             arr = MessageToDict(arr)
             genome_by_keyword_object = GenomeByKeyword(**arr)
             if (genome_by_keyword_object.release_version > latest_genome_by_keyword_object.release_version):
@@ -254,4 +257,3 @@ async def get_uuid(request: Request, assembly_accession_id: str):
     except Exception as ex:
         logging.error(ex)
         return response_error_handler({"status": 500})
-    return response_data


### PR DESCRIPTION
### Description
To resolve rapid urls with GCA accession, we need an endpoint to fetch this detail from grpc. After consulting with Bilal, we decided to use `GenomeBySpecificKeywordRequest`. This grpc endpoint returns an array of results from which we are picking up genome id and the release version. Release version is used in resolver to sort and find the latest genome id

### Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2830

### Review App URL(s) 
NA

### Knowledge Base
NA

### Checklist

- [ ] Black formatting
- [ ] Tests

### Dependencies 
No
