### PR TITLE
Add Endpoint to Fetch VEP File Paths

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -283,6 +283,42 @@ paths:
                     example: 'Could not find details for genome 0cbc227a-7179-43c2-8061-a50d94423c4d and dataset homologies.'
         '500':
           $ref: '#/components/responses/500InternalServerError'
+  /api/metadata/genome/{genome_id}/vep/file_paths:
+    get:
+      summary: Returns the VEP file paths for the specified genome
+      parameters:
+        - name: genome_id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 3704ceb1-948d-11ec-a39d-005056b38ce3
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  faaLocation:
+                    type: string
+                    example: Homo_sapiens/GCA_018473295.1/vep/genome/softmasked.fa.bgz
+                  gffLocation:
+                    type: string
+                    example: Homo_sapiens/GCA_018473295.1/vep/ensembl/geneset/2022_08/genes.gff3.bgz
+        '404':
+          description: Genome ID not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Genome ID not found"
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
   /api/metadata/genomeid/:
     get:
       summary: Returns the latest genome object

--- a/app/api/models/vep.py
+++ b/app/api/models/vep.py
@@ -1,0 +1,20 @@
+"""
+    See the NOTICE file distributed with this work for additional information
+    regarding copyright ownership.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class VepFilePaths(BaseModel):
+    faa_location: str = Field(alias="faaLocation")
+    gff_location: str = Field(alias="gffLocation")

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -157,3 +157,8 @@ class GRPCClient:
         request = request_class(**kwargs)
         response = self.stub.GetGenomesBySpecificKeyword(request)
         return response
+
+    def get_vep_file_paths(self, genome_uuid: str):
+        request_class = self.reflector.message_class("ensembl_metadata.GenomeUUIDOnlyRequest")
+        vep_file_paths_request = request_class(genome_uuid=genome_uuid)
+        return self.stub.GetVepFilePathsByUUID(vep_file_paths_request)

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -261,7 +261,7 @@ async def get_genome_by_keyword(request: Request, assembly_accession_id: str):
         logging.error(ex)
         return response_error_handler({"status": 500})
 
-@router.get("/genome/{genome_uuid}/vep/file_path")
+@router.get("/genome/{genome_uuid}/vep/file_paths")
 async def get_vep_file_paths(
     request: Request,
     genome_uuid: str,

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -279,10 +279,9 @@ async def get_vep_file_paths(
             )
 
         vep_file_paths_object = VepFilePaths(**vep_file_paths)
-        response_data = responses.JSONResponse(
+        return responses.JSONResponse(
             vep_file_paths_object.dict(), status_code=200
         )
-        return response_data
 
     except Exception as ex:
         logging.error(ex)

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -28,6 +28,7 @@ from api.models.popular_species import PopularSpeciesGroup
 from api.models.karyotype import Karyotype
 from api.models.genome import BriefGenomeDetails, GenomeDetails, DatasetAttributes, GenomeByKeyword
 from api.models.ftplinks import FTPLinks
+from api.models.vep import VepFilePaths
 
 from core.config import GRPC_HOST, GRPC_PORT
 from core.logging import InterceptHandler
@@ -255,6 +256,33 @@ async def get_genome_by_keyword(request: Request, assembly_accession_id: str):
         else:            
             logging.error(f"Assembly accession id {assembly_accession_id} not found")
             return response_error_handler({"status": 404})
+
+    except Exception as ex:
+        logging.error(ex)
+        return response_error_handler({"status": 500})
+
+@router.get("/genome/{genome_uuid}/vep/file_path")
+async def get_vep_file_paths(
+    request: Request,
+    genome_uuid: str,
+):
+    try:
+        vep_file_paths = MessageToDict(
+            grpc_client.get_vep_file_paths(genome_uuid=genome_uuid)
+        )
+        if len(vep_file_paths) == 0:
+            return responses.JSONResponse(
+                {
+                    "message": f"Could not find VEP file paths for genome {genome_uuid}."
+                },
+                status_code=404,
+            )
+
+        vep_file_paths_object = VepFilePaths(**vep_file_paths)
+        response_data = responses.JSONResponse(
+            vep_file_paths_object.dict(), status_code=200
+        )
+        return response_data
 
     except Exception as ex:
         logging.error(ex)


### PR DESCRIPTION
### Description
Added the endpoint to fetch VEP file paths

### Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/EA-1309

### Review App URL(s) 
http://update-vep-paths.review.ensembl.org (I don't know if/how this works)

### Example(s)
Request
```
http://0.0.0.0:8014/api/metadata/genome/3704ceb1-948d-11ec-a39d-005056b38ce3/vep/file_path
```
Response
```
{
  "faa_location": "Homo_sapiens/GCA_000001405.14/vep/genome/softmasked.fa.bgz",
  "gff_location": "Homo_sapiens/GCA_000001405.14/vep/ensembl/geneset/2013_09/genes.gff3.bgz"
}
```

### Dependencies 
The follwing PR needs to be merged first
* [Meatadata API + gRPC] https://github.com/Ensembl/ensembl-metadata-api/pull/126
