### PR TITLE
Add releases endpoint

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,9 +103,12 @@ Setup:Review:
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   environment:
     name: development
+  before_script:
+    - kubectl config use-context ${AGENT}
+    - kubectl config set-context --current --namespace=${NS}
   variables:
-    AGENT: ${REVIEW_AGENT}
-    NS: ${CI_COMMIT_REF_SLUG}
+    AGENT: ${DEV_AGENT}
+    NS: ${DEV_NS}
   script:
     - kubectl create namespace ${CI_COMMIT_REF_SLUG} --dry-run=client -o yaml | kubectl apply -f -
     - kubectl create configmap metadata-api-configmap --from-env-file=.env.sample --dry-run=client -o yaml | kubectl apply -f -

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,10 +107,10 @@ Setup:Review:
     - kubectl config use-context ${AGENT}
     - kubectl config set-context --current --namespace=${NS}
   variables:
-    AGENT: ${REVIEW_AGENT}
-    NS: ${CI_COMMIT_REF_SLUG}
+    AGENT: ${DEV_AGENT}
+    NS: ${DEV_NS}
   script:
-    - kubectl create namespace ${CI_COMMIT_REF_SLUG} --dry-run=client -o yaml | kubectl apply -f -
+    - kubectl create namespace ${DEV_NS} --dry-run=client -o yaml | kubectl apply -f -
     - kubectl create configmap metadata-api-configmap --from-env-file=.env.sample --dry-run=client -o yaml | kubectl apply -f -
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,6 +103,9 @@ Setup:Review:
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   environment:
     name: development
+  variables:
+    AGENT: ${REVIEW_AGENT}
+    NS: ${CI_COMMIT_REF_SLUG}
   script:
     - kubectl create namespace ${CI_COMMIT_REF_SLUG} --dry-run=client -o yaml | kubectl apply -f -
     - kubectl create configmap metadata-api-configmap --from-env-file=.env.sample --dry-run=client -o yaml | kubectl apply -f -

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ Setup:Review:
     - kubectl config use-context ${AGENT}
     - kubectl config set-context --current --namespace=${NS}
   variables:
-    AGENT: ${REVIEW_AGENTREVIEW_AGENT}
+    AGENT: ${REVIEW_AGENT}
     NS: ${CI_COMMIT_REF_SLUG}
   script:
     - kubectl create configmap metadata-api-configmap --from-env-file=.env.sample --dry-run=client -o yaml | kubectl apply -f -

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,10 +107,9 @@ Setup:Review:
     - kubectl config use-context ${AGENT}
     - kubectl config set-context --current --namespace=${NS}
   variables:
-    AGENT: ${DEV_AGENT}
-    NS: ${DEV_NS}
+    AGENT: ${REVIEW_AGENTREVIEW_AGENT}
+    NS: ${CI_COMMIT_REF_SLUG}
   script:
-    - kubectl create namespace ${DEV_NS} --dry-run=client -o yaml | kubectl apply -f -
     - kubectl create configmap metadata-api-configmap --from-env-file=.env.sample --dry-run=client -o yaml | kubectl apply -f -
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,8 +107,8 @@ Setup:Review:
     - kubectl config use-context ${AGENT}
     - kubectl config set-context --current --namespace=${NS}
   variables:
-    AGENT: ${DEV_AGENT}
-    NS: ${DEV_NS}
+    AGENT: ${REVIEW_AGENT}
+    NS: ${CI_COMMIT_REF_SLUG}
   script:
     - kubectl create namespace ${CI_COMMIT_REF_SLUG} --dry-run=client -o yaml | kubectl apply -f -
     - kubectl create configmap metadata-api-configmap --from-env-file=.env.sample --dry-run=client -o yaml | kubectl apply -f -

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -348,18 +348,6 @@ paths:
       description: Retrieve release data with filtering capabilities
       operationId: get_releases
       parameters:
-        - name: site_name
-          in: query
-          description: Filter by one or more site names
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-          style: form
-          explode: false
-          example:
-            value: [ "beta", "plants" ]
         - name: release_label
           in: query
           description: Filter by one or more release labels
@@ -397,17 +385,11 @@ paths:
                   release_label: "2025-06"
                   release_type: "integrated"
                   is_current: true
-                  site_name: "Ensembl"
-                  site_label: "Ensembl Beta"
-                  site_uri: "https://beta.ensembl.org"
                 - release_version: 110.1
                   release_date: "2024-01-10"
                   release_label: "2024-01"
                   release_type: "integrated"
                   is_current: false
-                  site_name: "Ensembl"
-                  site_label: "Ensembl 2024-01 Archive"
-                  site_uri: "https://2024-01.ensembl.org"
         '404':
           description: No releases found
           content:
@@ -476,6 +458,9 @@ components:
             release_label:
               type: string
               example: 2023-10-18
+            is_current:
+              type: boolean
+              example: true
         type:
           $ref: '#/components/schemas/SpeciesTypeInGenome'
           nullable: true
@@ -1114,25 +1099,12 @@ components:
         is_current:
           type: boolean
           example: true
-        site_name:
-          type: string
-          example: "Ensembl"
-        site_label:
-          type: string
-          example: "Ensembl Beta"
-        site_uri:
-          type: string
-          format: uri
-          example: "https://beta.ensembl.org"
       required:
         - release_version
         - release_date
         - release_label
         - release_type
         - is_current
-        - site_name
-        - site_label
-        - site_uri
   responses:
     404NotFound:
       description: The specified resource was not found

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -348,7 +348,7 @@ paths:
       description: Retrieve release data with filtering capabilities
       operationId: get_releases
       parameters:
-        - name: release_label
+        - name: release_name
           in: query
           description: Filter by one or more release labels
           required: false
@@ -380,14 +380,12 @@ paths:
                 items:
                   $ref: '#/components/schemas/Release'
               example:
-                - release_version: 114.0
-                  release_date: "2025-06-15"
-                  release_label: "2025-06"
+                - release_date: "2025-06-15"
+                  release_name: "2025-06"
                   release_type: "integrated"
                   is_current: true
-                - release_version: 110.1
-                  release_date: "2024-01-10"
-                  release_label: "2024-01"
+                - release_date: "2024-01-10"
+                  release_name: "2024-01"
                   release_type: "integrated"
                   is_current: false
         '404':
@@ -446,16 +444,13 @@ components:
         release:
           type: object
           properties:
-            release_version:
-              type: number
-              example: 110.1
             release_date:
               type: string
               example: 2023-10-18
             release_type:
               type: string
               example: partial
-            release_label:
+            release_name:
               type: string
               example: 2023-10-18
             is_current:
@@ -1081,15 +1076,11 @@ components:
     Release:
       type: object
       properties:
-        release_version:
-          type: number
-          format: double
-          example: 110.1
         release_date:
           type: string
           format: date
           example: "2024-03-15"
-        release_label:
+        release_name:
           type: string
           example: "2023-10-18"
         release_type:
@@ -1100,9 +1091,8 @@ components:
           type: boolean
           example: true
       required:
-        - release_version
         - release_date
-        - release_label
+        - release_name
         - release_type
         - is_current
   responses:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -372,34 +372,15 @@ paths:
             value: true
       responses:
         '200':
-          description: Successful operation
+          description: successful operation
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Release'
-              example:
-                - release_date: "2025-06-15"
-                  release_name: "2025-06"
-                  release_type: "integrated"
-                  is_current: true
-                - release_date: "2024-01-10"
-                  release_name: "2024-01"
-                  release_type: "integrated"
-                  is_current: false
+                $ref: '#/components/schemas/Release'
         '404':
-          description: No releases found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundError'
+          $ref: '#/components/responses/404NotFound'
         '500':
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ServerError'
+          $ref: '#/components/responses/500InternalServerError'
 
 components:
   schemas:
@@ -442,20 +423,7 @@ components:
               type: string
               example: GRCh38.p13
         release:
-          type: object
-          properties:
-            release_date:
-              type: string
-              example: 2023-10-18
-            release_type:
-              type: string
-              example: partial
-            release_name:
-              type: string
-              example: 2023-10-18
-            is_current:
-              type: boolean
-              example: true
+          $ref: '#/components/schemas/Release'
         type:
           $ref: '#/components/schemas/SpeciesTypeInGenome'
           nullable: true

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -348,9 +348,9 @@ paths:
       description: Retrieve release data with filtering capabilities
       operationId: get_releases
       parameters:
-        - name: release_name
+        - name: name
           in: query
-          description: Filter by one or more release labels
+          description: Filter by one or more release names
           required: false
           schema:
             type: array
@@ -423,7 +423,14 @@ components:
               type: string
               example: GRCh38.p13
         release:
-          $ref: '#/components/schemas/Release'
+          type: object
+          properties:
+            name:
+              type: string
+              example: 2023-10-18
+            type:
+              type: string
+              example: partial
         type:
           $ref: '#/components/schemas/SpeciesTypeInGenome'
           nullable: true
@@ -1044,14 +1051,10 @@ components:
     Release:
       type: object
       properties:
-        release_date:
-          type: string
-          format: date
-          example: "2024-03-15"
-        release_name:
+        name:
           type: string
           example: "2023-10-18"
-        release_type:
+        type:
           type: string
           enum: [ integrated, partial ]
           example: "partial"
@@ -1059,9 +1062,8 @@ components:
           type: boolean
           example: true
       required:
-        - release_date
-        - release_name
-        - release_type
+        - name
+        - type
         - is_current
   responses:
     404NotFound:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -340,6 +340,86 @@ paths:
           $ref: '#/components/responses/404NotFound'
         '500':
           $ref: '#/components/responses/500InternalServerError'
+  /api/metadata/releases:
+    get:
+      tags:
+        - Releases
+      summary: Get release information
+      description: Retrieve release data with filtering capabilities
+      operationId: get_releases
+      parameters:
+        - name: site_name
+          in: query
+          description: Filter by one or more site names
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: false
+          example:
+            value: [ "beta", "plants" ]
+        - name: release_label
+          in: query
+          description: Filter by one or more release labels
+          required: false
+          schema:
+            type: array
+            items:
+              type: number
+              format: double
+          style: form
+          explode: false
+          example:
+            value: [ "2023-10-18", "2024-09" ]
+        - name: current_only
+          in: query
+          description: Return only current partial and integrated releases
+          required: false
+          schema:
+            type: boolean
+            default: false
+          example:
+            value: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Release'
+              example:
+                - release_version: 114.0
+                  release_date: "2025-06-15"
+                  release_label: "2025-06"
+                  release_type: "integrated"
+                  is_current: true
+                  site_name: "Ensembl"
+                  site_label: "Ensembl Beta"
+                  site_uri: "https://beta.ensembl.org"
+                - release_version: 110.1
+                  release_date: "2024-01-10"
+                  release_label: "2024-01"
+                  release_type: "integrated"
+                  is_current: false
+                  site_name: "Ensembl"
+                  site_label: "Ensembl 2024-01 Archive"
+                  site_uri: "https://2024-01.ensembl.org"
+        '404':
+          description: No releases found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerError'
 
 components:
   schemas:
@@ -381,6 +461,21 @@ components:
             name:
               type: string
               example: GRCh38.p13
+        release:
+          type: object
+          properties:
+            release_version:
+              type: number
+              example: 110.1
+            release_date:
+              type: string
+              example: 2023-10-18
+            release_type:
+              type: string
+              example: partial
+            release_label:
+              type: string
+              example: 2023-10-18
         type:
           $ref: '#/components/schemas/SpeciesTypeInGenome'
           nullable: true
@@ -998,6 +1093,46 @@ components:
         - url
       additionalProperties: false
       description: FTP link to a dataset directory for a genome
+    Release:
+      type: object
+      properties:
+        release_version:
+          type: number
+          format: double
+          example: 110.1
+        release_date:
+          type: string
+          format: date
+          example: "2024-03-15"
+        release_label:
+          type: string
+          example: "2023-10-18"
+        release_type:
+          type: string
+          enum: [ integrated, partial ]
+          example: "partial"
+        is_current:
+          type: boolean
+          example: true
+        site_name:
+          type: string
+          example: "Ensembl"
+        site_label:
+          type: string
+          example: "Ensembl Beta"
+        site_uri:
+          type: string
+          format: uri
+          example: "https://beta.ensembl.org"
+      required:
+        - release_version
+        - release_date
+        - release_label
+        - release_type
+        - is_current
+        - site_name
+        - site_label
+        - site_uri
   responses:
     404NotFound:
       description: The specified resource was not found

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -27,7 +27,7 @@ class Type(BaseModel):
         return value
 
 
-class ReleaseInGenome(BaseModel):
+class Release(BaseModel):
     release_label: str = Field(alias="releaseLabel")
     release_date: str = Field(alias="releaseDate")
     release_type: str = Field(alias="releaseType")
@@ -85,7 +85,7 @@ class BaseGenomeDetails(BaseModel):
         alias=AliasPath("assembly", "isReference"), default=False
     )
     assembly: AssemblyInGenome = None
-    release: ReleaseInGenome = None
+    release: Release = None
 
 
 class BriefGenomeDetails(BaseGenomeDetails):

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -27,6 +27,13 @@ class Type(BaseModel):
         return value
 
 
+class ReleaseInGenome(BaseModel):
+    release_label: str = Field(alias="releaseLabel")
+    release_date: str = Field(alias="releaseDate")
+    release_type: str = Field(alias="releaseType")
+    release_version: float = Field(alias="releaseVersion")
+
+
 class AssemblyInGenome(BaseModel):
     accession_id: str = Field(alias="accession")
     name: str = Field(alias="name")
@@ -78,6 +85,7 @@ class BaseGenomeDetails(BaseModel):
         alias=AliasPath("assembly", "isReference"), default=False
     )
     assembly: AssemblyInGenome = None
+    release: ReleaseInGenome = None
 
 
 class BriefGenomeDetails(BaseGenomeDetails):

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -28,9 +28,8 @@ class Type(BaseModel):
 
 
 class Release(BaseModel):
-    release_name: str = Field(alias="releaseLabel")
-    release_date: str = Field(alias="releaseDate")
-    release_type: str = Field(alias="releaseType")
+    name: str = Field(alias="releaseLabel")
+    type: str = Field(alias="releaseType")
     is_current: bool = Field(alias="isCurrent", default=False)
 
 

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -28,10 +28,10 @@ class Type(BaseModel):
 
 
 class Release(BaseModel):
-    release_label: str = Field(alias="releaseLabel")
+    release_name: str = Field(alias="releaseLabel")
     release_date: str = Field(alias="releaseDate")
     release_type: str = Field(alias="releaseType")
-    release_version: float = Field(alias="releaseVersion")
+    is_current: bool = Field(alias="isCurrent", default=False)
 
 
 class AssemblyInGenome(BaseModel):

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -50,27 +50,19 @@ class GRPCClient:
         return toplevel_stats_by_uuid
 
     def get_genome_details(self, genome_uuid: str):
-        # Create request
         request_class = self.reflector.message_class(
             "ensembl_metadata.GenomeUUIDRequest"
         )
         request = request_class(genome_uuid=genome_uuid)
-
-        # Get response
         response = self.stub.GetGenomeByUUID(request)
-
         return response
 
     def get_brief_genome_details(self, genome_uuid_or_slug: str):
-        # Create request
         request_class = self.reflector.message_class(
             "ensembl_metadata.GenomeUUIDRequest"
         )
         request = request_class(genome_uuid=genome_uuid_or_slug)
-
-        # Get response
         response = self.stub.GetBriefGenomeDetailsByUUID(request)
-
         return response
 
     def get_attributes_info(self, genome_uuid: str):
@@ -78,9 +70,7 @@ class GRPCClient:
             "ensembl_metadata.GenomeUUIDRequest"
         )
         request = request_class(genome_uuid=genome_uuid)
-
         response = self.stub.GetAttributesByGenomeUUID(request)
-
         return response
 
     def get_popular_species(self):
@@ -88,7 +78,6 @@ class GRPCClient:
             "ensembl_metadata.OrganismsGroupRequest"
         )
         popular_species = self.stub.GetOrganismsGroupCount(request_class())
-
         return popular_species
 
     def get_top_level_regions(self, genome_uuid: str):
@@ -162,3 +151,10 @@ class GRPCClient:
         request_class = self.reflector.message_class("ensembl_metadata.GenomeUUIDOnlyRequest")
         vep_file_paths_request = request_class(genome_uuid=genome_uuid)
         return self.stub.GetVepFilePathsByUUID(vep_file_paths_request)
+
+    def get_release(self, site_name: list[str], release_label: list[str], current_only: bool):
+        request_class = self.reflector.message_class("ensembl_metadata.ReleaseRequest")
+        request = request_class(
+            site_name=site_name, release_label=release_label, current_only=current_only
+        )
+        return self.stub.GetRelease(request)

--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -152,9 +152,7 @@ class GRPCClient:
         vep_file_paths_request = request_class(genome_uuid=genome_uuid)
         return self.stub.GetVepFilePathsByUUID(vep_file_paths_request)
 
-    def get_release(self, site_name: list[str], release_label: list[str], current_only: bool):
+    def get_release(self, release_label: list[str], current_only: bool):
         request_class = self.reflector.message_class("ensembl_metadata.ReleaseRequest")
-        request = request_class(
-            site_name=site_name, release_label=release_label, current_only=current_only
-        )
+        request = request_class(release_label=release_label, current_only=current_only)
         return self.stub.GetRelease(request)

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -178,7 +178,7 @@ async def explain_genome(request: Request, genome_id_or_slug: str):
                     "common_name": True,
                     "is_reference": True,
                     "assembly": {"name", "accession_id"},
-                    "release": {"release_date", "release_label", "release_type", "release_version"},
+                    "release": {"release_date", "release_name", "release_type", "is_current"},
                     "type": True,
                 }
             )
@@ -313,10 +313,9 @@ async def get_releases(
             for release in releases_list:
                 response_dict = release.model_dump(
                     include={
-                        "release_label": True,
+                        "release_name": True,
                         "release_date": True,
                         "release_type": True,
-                        "release_version": True,
                         "is_current": True,
                     }
                 )

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -128,7 +128,11 @@ async def get_genome_details(request: Request, genome_uuid: str):
         genome_details_dict = MessageToDict(grpc_client.get_genome_details(genome_uuid))
         if genome_details_dict:
             genome_details = GenomeDetails(**genome_details_dict)
-            response_data = responses.JSONResponse(genome_details.model_dump())
+            response_data = responses.JSONResponse(genome_details.model_dump(
+                exclude={
+                    "release": {"is_current"},
+                }
+            ))
         else:
             not_found_response = {
                 "message": "Could not find details for {}".format(genome_uuid)
@@ -178,7 +182,7 @@ async def explain_genome(request: Request, genome_id_or_slug: str):
                     "common_name": True,
                     "is_reference": True,
                     "assembly": {"name", "accession_id"},
-                    "release": {"release_date", "release_name", "release_type", "is_current"},
+                    "release": {"name", "type"},
                     "type": True,
                 }
             )
@@ -313,9 +317,8 @@ async def get_releases(
             for release in releases_list:
                 response_dict = release.model_dump(
                     include={
-                        "release_name": True,
-                        "release_date": True,
-                        "release_type": True,
+                        "name": True,
+                        "type": True,
                         "is_current": True,
                     }
                 )


### PR DESCRIPTION
### Description
Add `/releases` endpoint which returns all the releases (for now)

### Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2908

### Review URL
http://add-releases-endpoint.review.ensembl.org/api/metadata/releases

### Example(s)
#### Request
```
/api/metadata/releases
```

#### Response
```
[
  {
    "name": "2023-10-18",
    "type": "partial",
    "is_current": false
  },
  {
    "name": "2024-09-18",
    "type": "partial",
    "is_current": false
  },
  {
    "name": "2024-10-28",
    "type": "partial",
    "is_current": false
  },
  {
    "name": "2023-10",
    "type": "integrated",
    "is_current": true
  },
  {
    "name": "2025-01-16",
    "type": "partial",
    "is_current": true
  },
  {
    "name": "2025-02-28",
    "type": "partial",
    "is_current": false
  }
]
```

### Dependencies 
This PR needs to be merged and deployed first: https://github.com/Ensembl/ensembl-metadata-api/pull/128
