### PR TITLE
Add `GET /grpc_status` endpoint

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -11,6 +11,35 @@ tags:
   - name: api
     description: Ensembl Web Metadata API
 paths:
+  /grpc_status:
+    get:
+      summary: Check gRPC Server or Service Health
+      description: |
+        - If `service_name` is not provided, it checks the overall gRPC server health.
+        - If `service_name` is provided, it checks that specific service (e.g. `EnsemblMetadata`).
+      parameters:
+        - name: service_name
+          in: query
+          required: false
+          schema:
+            type: string
+          description: The specific gRPC service name to check (leave empty for global health check).
+      responses:
+        200:
+          description: gRPC service is running and healthy.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 1
+                  code:
+                    type: string
+                    example: "OK"
+        503:
+          '$ref': '#/components/responses/503ServiceUnavailable'
   /api/metadata/genome/{genome_id_or_slug}/explain:
     get:
       description: Satisfies client's need to disambiguate a string that is part of url pathname
@@ -1006,6 +1035,19 @@ components:
           schema:
             type: string
             example: '{"status_code": 404, "details": "Not Found"}'
+    503ServiceUnavailable:
+      description: gRPC service is unavailable.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 0
+              code:
+                type: string
+                example: "UNAVAILABLE"
     500InternalServerError:
       description: Internal server error
       content:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ click==8.1.7
 exceptiongroup==1.2.0
 fastapi==0.103.1
 grpcio==1.60.0
+grpcio-health-checking==1.60.0
 grpcio-tools==1.60.0
 h11==0.14.0
 idna==3.6


### PR DESCRIPTION
> I was working on this a while ago I didn't want it to go to wast

### Description
This PR add an endpoint that can be used to check the health status of gRPC server
![image](https://github.com/user-attachments/assets/975d91c1-e412-44bf-bffb-eb7c77222f27)


### Knowledge Base
Official Docs of how it works: https://grpc.io/docs/guides/health-checking/

### Example(s)
#### Request
```
http://0.0.0.0:8014/api/metadata/grpc_status
```

#### Response when it's UP (`200`)
```
{
  "status": 1,
  "code": "OK"
}
```

#### Response when it's DOWN (`503`)
```
{
  "status": 0,
  "code": "UNAVAILABLE"
}
```
### Dependencies 
This gRPC PR needs to be merged and deployed first: https://github.com/Ensembl/ensembl-metadata-api/pull/127
