### PR TITLE
Add latest_genome

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -436,6 +436,9 @@ components:
           nullable: true
         is_reference:
           type: boolean
+        latest_genome:
+          $ref: '#/components/schemas/BriefGenomeDetails'
+          nullable: true
       required:
         - genome_id
         - genome_tag
@@ -445,6 +448,7 @@ components:
         - assembly_name
         - type
         - is_reference
+        - latest_genome
     GenomeStats:
       type: object
       properties:

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -93,7 +93,7 @@ class BriefGenomeDetails(BaseGenomeDetails):
     We're planning to extend the BriefGenomeDetails class later but for now,
     we will leave it as an empty extension of BaseGenomeDetails
     """
-    pass
+    latest_genome: Optional[BaseGenomeDetails] = None
 
 
 class GenomeDetails(BaseGenomeDetails):

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -184,6 +184,7 @@ async def explain_genome(request: Request, genome_id_or_slug: str):
                     "assembly": {"name", "accession_id"},
                     "release": {"name", "type"},
                     "type": True,
+                    "latest_genome": True,
                 }
             )
             response_data = responses.JSONResponse(response_dict, status_code=200)


### PR DESCRIPTION
### Description
This PR adds latest_genome object to the explain endoint payload.
The object will contain details for a genome if it supersedes the queried one.
Corresponding PR in gRPC service: https://github.com/Ensembl/ensembl-metadata-api/pull/132

### Related JIRA Issue(s)
[ENSPLAT-93](https://embl.atlassian.net/browse/ENSPLAT-93)

### Review App URL(s) 
http://explain-latest-genome.review.ensembl.org

### Knowledge Base
Schematic for selecting the latest genome: https://excalidraw.com/#json=6eq31mq25UngHsbHCEHTS,in8ymfswvZkHP1MimNgp-g

### Example(s)
http://explain-latest-genome.review.ensembl.org/genome/8bce37f6-5353-4fb4-962f-f7e9a6c4303d
The response should include details for ce9c01fe-1d5c-4fea-a96a-b8eb3c3586f4

### Checklist

- [ ] Black formatting
- [ ] Tests

### Dependencies 
Upstream PR: https://github.com/Ensembl/ensembl-metadata-api/pull/132
