### PR TITLE
Set `genome_tag` for partial release

### DIFF
--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -86,6 +86,11 @@ class BaseGenomeDetails(BaseModel):
     assembly: AssemblyInGenome = None
     release: Release = None
 
+    def model_post_init(self, __context):
+        """Set genome_tag to None if the release type is 'partial'."""
+        if self.release and self.release.type == "partial":
+            self.genome_tag = None
+
 
 class BriefGenomeDetails(BaseGenomeDetails):
     """


### PR DESCRIPTION
### Description
<!--
_Using one or more sentences, describe the proposed changes and the reason for making them._
-->

### Related JIRA Issue(s)
https://embl.atlassian.net/browse/ENSPLAT-166

### Review App URL(s) 
TBD

### Example(s)
After the patch:

##### `/explain`

> Old integrated genome: `/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/explain`

```
{
  "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3",
  "genome_tag": "grch38",
  "common_name": "Human",
  "scientific_name": "Homo sapiens",
  "type": null,
  "is_reference": true,
  "assembly": {
    "accession_id": "GCA_000001405.29",
    "name": "GRCh38.p14"
  },
  "release": {
    "name": "2025-02",
    "type": "integrated"
  },
  "latest_genome": {
    "genome_id": "2b5fb047-5992-4dfb-b2fa-1fb4e18d1abb",
    "genome_tag": null,           <--- It's null for partial! YAY!
    "common_name": "Human",
    "scientific_name": "Homo sapiens",
    "type": null,
    "is_reference": true,
    "assembly": {
      "accession_id": "GCA_000001405.29",
      "name": "GRCh38.p14",
      "url": "https://identifiers.org/insdc.gca/GCA_000001405.29"
    },
    "release": {
      "name": "2025-04-28",
      "type": "partial",
      "is_current": true
    }
  }
}
```

> New partial genome: `/api/metadata/genome/2b5fb047-5992-4dfb-b2fa-1fb4e18d1abb/explain`

```
{
  "genome_id": "2b5fb047-5992-4dfb-b2fa-1fb4e18d1abb",
  "genome_tag": null,           <--- It's null for partial! YAY!
  "common_name": "Human",
  "scientific_name": "Homo sapiens",
  "type": null,
  "is_reference": true,
  "assembly": {
    "accession_id": "GCA_000001405.29",
    "name": "GRCh38.p14"
  },
  "release": {
    "name": "2025-04-28",
    "type": "partial"
  },
  "latest_genome": null
}
```

> How about using tag?: `/api/metadata/genome/grch38/explain`
> NOICE! equivalent to providing the old integrated genome UUID
```
{
  "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3",
  "genome_tag": "grch38",
  "common_name": "Human",
  "scientific_name": "Homo sapiens",
  "type": null,
  "is_reference": true,
  "assembly": {
    "accession_id": "GCA_000001405.29",
    "name": "GRCh38.p14"
  },
  "release": {
    "name": "2025-02",
    "type": "integrated"
  },
  "latest_genome": {
    "genome_id": "2b5fb047-5992-4dfb-b2fa-1fb4e18d1abb",
    "genome_tag": null,           <--- Still null as we would like it to be
    "common_name": "Human",
    "scientific_name": "Homo sapiens",
    "type": null,
    "is_reference": true,
    "assembly": {
      "accession_id": "GCA_000001405.29",
      "name": "GRCh38.p14",
      "url": "https://identifiers.org/insdc.gca/GCA_000001405.29"
    },
    "release": {
      "name": "2025-04-28",
      "type": "partial",
      "is_current": true
    }
  }
}
```
##### `/details`

> Old integrated genome: `/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/details`
```
{
  "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3",
  "genome_tag": "grch38",       <-- The tag is there as expected
  "common_name": "Human",
  "scientific_name": "Homo sapiens",
  "type": null,
  "is_reference": true,
  "assembly": {
    "accession_id": "GCA_000001405.29",
    "name": "GRCh38.p14",
    "url": "https://identifiers.org/insdc.gca/GCA_000001405.29"
  },
  "release": {
    "name": "2025-02",
    "type": "integrated"
  },
  "taxonomy_id": "9606",
  "species_taxonomy_id": "9606",
  "assembly_provider": null,
  "assembly_level": "chromosome",
  "assembly_date": "2013-12",
  "annotation_provider": {
    "name": "Ensembl",
    "url": "https://www.ensembl.org"
  },
  "annotation_method": "Ensembl Genebuild",
  "annotation_version": "44",
  "annotation_date": "2023-09",
  "number_of_genomes_in_group": 262
}
```

> New partial genome: `/api/metadata/genome/2b5fb047-5992-4dfb-b2fa-1fb4e18d1abb/explain`

```
{
  "genome_id": "2b5fb047-5992-4dfb-b2fa-1fb4e18d1abb",
  "genome_tag": null,       <-- Aaand it's gone, as expected
  "common_name": "Human",
  "scientific_name": "Homo sapiens",
  "type": null,
  "is_reference": true,
  "assembly": {
    "accession_id": "GCA_000001405.29",
    "name": "GRCh38.p14",
    "url": "https://identifiers.org/insdc.gca/GCA_000001405.29"
  },
  "release": {
    "name": "2025-04-28",
    "type": "partial"
  },
  "taxonomy_id": "9606",
  "species_taxonomy_id": "9606",
  "assembly_provider": null,
  "assembly_level": "chromosome",
  "assembly_date": "2013-12",
  "annotation_provider": {
    "name": "GENCODE",
    "url": "https://gencodegenes.org/"
  },
```
