### PR TITLE
Proper 404 handling

### DIFF
--- a/app/api/error_response.py
+++ b/app/api/error_response.py
@@ -11,18 +11,19 @@ from starlette.status import (
 
 
 def response_error_handler(result):
-    if result["status"] == 501:
-        return http_501_not_implemented()
-    if result["status"] == 500:
-        return http_500_internal_server_error()
-    if result["status"] == 406:
-        return http_406_not_acceptable()
-    if result["status"] == 400:
-        return http_400_bad_request()
-    if result["status"] == 501:
-        return http_501_not_implemented()
-    if result["status"] == 404:
-        return http_404_not_found()
+    status = result.get("status")
+    details = result.get("details")
+
+    if status == 400:
+        return http_400_bad_request(details)
+    elif status == 404:
+        return http_404_not_found(details)
+    elif status == 406:
+        return http_406_not_acceptable(details)
+    elif status == 500:
+        return http_500_internal_server_error(details)
+    elif status == 501:
+        return http_501_not_implemented(details)
     else:
         return http_unknown_error(result)
 
@@ -32,42 +33,41 @@ def http_unknown_error(result):
     return PlainTextResponse(response_msg, status_code=result["status"])
 
 
-def http_400_bad_request():
-    response_msg = json.dumps(
-        {"status_code": HTTP_400_BAD_REQUEST, "details": "Bad Request"}
-    )
+def http_400_bad_request(details: str = "Bad Request"):
+    response_msg = json.dumps({
+        "status_code": HTTP_400_BAD_REQUEST,
+        "details": details
+    })
     return PlainTextResponse(response_msg, status_code=HTTP_400_BAD_REQUEST)
 
 
-def http_404_not_found():
-    response_msg = json.dumps(
-        {"status_code": HTTP_404_NOT_FOUND, "details": "Not Found"}
-    )
+def http_404_not_found(details: str = "Not Found"):
+    response_msg = json.dumps({
+        "status_code": HTTP_404_NOT_FOUND,
+        "details": details
+    })
     return PlainTextResponse(response_msg, status_code=HTTP_404_NOT_FOUND)
 
 
-def http_406_not_acceptable():
-    response_msg = json.dumps(
-        {"status_code": HTTP_406_NOT_ACCEPTABLE, "details": "Not Acceptable"}
-    )
+def http_406_not_acceptable(details: str = "Not Acceptable"):
+    response_msg = json.dumps({
+        "status_code": HTTP_406_NOT_ACCEPTABLE,
+        "details": details
+    })
     return PlainTextResponse(response_msg, status_code=HTTP_406_NOT_ACCEPTABLE)
 
 
-def http_501_not_implemented():
-    response_msg = json.dumps(
-        {
-            "status_code": HTTP_501_NOT_IMPLEMENTED,
-            "details": "Not Implemented",
-        }
-    )
+def http_501_not_implemented(details: str = "Not Implemented"):
+    response_msg = json.dumps({
+        "status_code": HTTP_501_NOT_IMPLEMENTED,
+        "details": details
+    })
     return PlainTextResponse(response_msg, status_code=HTTP_501_NOT_IMPLEMENTED)
 
 
-def http_500_internal_server_error():
-    response_msg = json.dumps(
-        {
-            "status_code": HTTP_500_INTERNAL_SERVER_ERROR,
-            "details": "Internal Server Error",
-        }
-    )
+def http_500_internal_server_error(details: str = "Internal Server Error"):
+    response_msg = json.dumps({
+        "status_code": HTTP_500_INTERNAL_SERVER_ERROR,
+        "details": details
+    })
     return PlainTextResponse(response_msg, status_code=HTTP_500_INTERNAL_SERVER_ERROR)

--- a/app/api/resources/metadata.py
+++ b/app/api/resources/metadata.py
@@ -116,12 +116,10 @@ async def example_objects(request: Request, genome_id: str):
                 example_objects.model_dump()["example_objects"]
             )
         else:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Could not find example objects for {genome_id}"
-            )
-    except HTTPException:
-        raise
+            return response_error_handler({
+                "status": 404,
+                "details": f"Could not find example objects for {genome_id}"
+            })
     except Exception as ex:
         logging.error(ex)
         return response_error_handler({"status": 500})
@@ -141,12 +139,10 @@ async def get_genome_details(request: Request, genome_uuid: str):
                 }
             ))
         else:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Could not find details for {genome_uuid}"
-            )
-    except HTTPException:
-        raise
+            return response_error_handler({
+                "status": 404,
+                "details": f"Could not find details for {genome_uuid}"
+            })
     except Exception as ex:
         logging.error(ex)
         return response_error_handler({"status": 500})
@@ -198,9 +194,10 @@ async def explain_genome(request: Request, genome_id_or_slug: str):
             )
             response_data = responses.JSONResponse(response_dict, status_code=200)
         else:
-            raise HTTPException(status_code=404, detail=f"Could not explain {genome_id_or_slug}")
-    except HTTPException:
-        raise
+            return response_error_handler({
+                "status": 404,
+                "details": f"Could not explain {genome_id_or_slug}"
+            })
     except Exception as ex:
         logging.error(ex)
         return response_error_handler({"status": 500})
@@ -340,12 +337,10 @@ async def get_releases(
                 response_list.append(response_dict)
             response_data = responses.JSONResponse(response_list, status_code=200)
         else:
-            raise HTTPException(
-                status_code=404,
-                detail="No releases found matching criteria"
-            )
-    except HTTPException:
-        raise
+            return response_error_handler({
+                "status": 404,
+                "details": "No releases found matching criteria"
+            })
     except Exception as e:
         logging.error(e)
         error_response = {"message": f"An error occurred: {str(e)}"}


### PR DESCRIPTION
### Description
`/explain` and other endpoints return `200` (instead of `404`) with the error message when fetching data from cache

This PR uses `error_response.py` properly and made it customizable

### Review App URL(s) 
http://handle-404-error.review.ensembl.org

### Examples

Triticum aestivum:
```
curl  "http://handle-404-error.review.ensembl.org/api/metadata/genome/a73357ab-93e7-11ec-a39d-005056b38ce3/explain" -v
...
* Request completely sent off
< HTTP/1.1 200 OK
< Date: Mon, 23 Jun 2025 13:17:42 GMT
< Content-Type: application/json
< Content-Length: 302
< Connection: keep-alive
<
* Connection #0 to host handle-404-error.review.ensembl.org left intact
{"genome_id":"a73357ab-93e7-11ec-a39d-005056b38ce3","genome_tag":"iwgsc","common_name":"Bread wheat","scientific_name":"Triticum aestivum","type":null,"is_reference":true,"assembly":{"accession_id":"GCA_900519105.1","name":"IWGSC"},"release":{"name":"2025-02","type":"integrated"},"latest_genome":null}
```

Bad UUID:
```
curl  "http://handle-404-error.review.ensembl.org/api/metadata/genome/a73357ab-93e7-11ec-a39d-005056b38bad/explain" -v
...
* Request completely sent off
< HTTP/1.1 404 Not Found
< Date: Mon, 23 Jun 2025 13:17:55 GMT
< Content-Type: application/json
< Content-Length: 68
< Connection: keep-alive
<
* Connection #0 to host handle-404-error.review.ensembl.org left intact
{"message":"Could not explain a73357ab-93e7-11ec-a39d-005056b38bad"}
```