### PR TITLE
Add `species_taxonomy_id` to `/explain` response

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -412,6 +412,9 @@ components:
           nullable: true
         scientific_name:
           type: string
+          example: 9606
+        species_taxonomy_id:
+          type: string
           example: Homo sapiens
         assembly:
           type: object

--- a/app/api/models/genome.py
+++ b/app/api/models/genome.py
@@ -79,12 +79,17 @@ class BaseGenomeDetails(BaseModel):
     )
     common_name: str = Field(alias=AliasPath("organism", "commonName"), default=None)
     scientific_name: str = Field(alias=AliasPath("organism", "scientificName"))
+    species_taxonomy_id: str = Field(alias=AliasPath("organism", "speciesTaxonomyId"))
     type: Optional[Type] = None
     is_reference: bool = Field(
         alias=AliasPath("assembly", "isReference"), default=False
     )
     assembly: AssemblyInGenome = None
     release: Release = None
+
+    @validator("species_taxonomy_id", pre=True)
+    def convert_int_to_str(cls, value):
+        return str(value)
 
     def model_post_init(self, __context):
         """Set genome_tag to None if the release type is 'partial'."""
@@ -102,7 +107,6 @@ class BriefGenomeDetails(BaseGenomeDetails):
 
 class GenomeDetails(BaseGenomeDetails):
     taxonomy_id: str = Field(alias=AliasPath("organism", "taxonomyId"))
-    species_taxonomy_id: str = Field(alias=AliasPath("organism", "speciesTaxonomyId"))
     assembly_provider: AssemblyProvider = None
     assembly_level: str = Field(alias=AliasPath("attributesInfo", "assemblyLevel"))
     assembly_date: str = Field(


### PR DESCRIPTION
### Description
There wa a bug in Ensembl Beta du to `/explain` not having `species_taxonomy_id` in the response

### Related JIRA Issue(s)
https://embl.atlassian.net/browse/ENSPLAT-208

### Review App URL(s) 
TBD

### Knowledge Base
Slack discussion: https://genomes-ebi.slack.com/archives/CC2RKR525/p1750948648601529

### Example(s)
```
{
  "genome_id": "2b5fb047-5992-4dfb-b2fa-1fb4e18d1abb",
  "genome_tag": null,
  "common_name": "Human",
  "scientific_name": "Homo sapiens",
  "species_taxonomy_id": "9606", <---- the newly added field
  "type": null,
  "is_reference": true,
  "assembly": {
    "accession_id": "GCA_000001405.29",
    "name": "GRCh38.p14"
  },
  "release": {
    "name": "2025-04-28",
    "type": "partial"
  },
  "latest_genome": null
}
```