### PR TITLE
Fix Rank Sorting

### DIFF
--- a/app/api/resources/grpc_client.py
+++ b/app/api/resources/grpc_client.py
@@ -91,8 +91,21 @@ class GRPCClient:
         genome_top_level_regions = []
         for tlr in top_level_regions:
             genome_top_level_regions.append(MessageToDict(tlr))
-        # Sort region by reank
-        genome_top_level_regions.sort(key=lambda region: region["rank"])
+
+        # Sort the list of regions by two criteria:
+        # 1. By "rank" if present, regions without a rank are considered to have the highest possible rank (so they go last)
+        # 2. Then by "length", which is stored as a string, so we convert it to an integer for proper numeric sorting
+        genome_top_level_regions.sort(
+            key=lambda region: (
+                # Use the value of "rank" if it exists, otherwise use infinity
+                # This ensures regions without a rank are placed at the end of the list
+                region.get("rank", float("inf")),
+
+                # Convert the "length" from string to integer so numeric comparison works correctly
+                # If "length" is missing, treat it as 0
+                int(region.get("length", 0))
+            )
+        )
         return genome_top_level_regions
 
     def get_region(self, genome_uuid: str, region_name: str):


### PR DESCRIPTION
### Description
This PR updates the `get_top_level_regions `method to apply a more consistent and meaningful sorting of regions by:

* `rank` (if present): regions without a rank are sorted last.
* `length`: numerically sorted.

### Review App URL(s) / Example
[Before](https://beta.ensembl.org/genome-browser/e5a7a144-340f-4455-91ba-5f31e9b47067?focus=gene:SPAC2F7.03c&location=I:532245-539744) ([Endpoint](https://beta.ensembl.org/api/metadata/genome/e5a7a144-340f-4455-91ba-5f31e9b47067/karyotype)):
<img width="362" height="432" alt="image" src="https://github.com/user-attachments/assets/1a2fba40-ab5b-4a56-88bc-ac6a48509357" />

Vs [After](https://dev-2020.ensembl.org/genome-browser/e5a7a144-340f-4455-91ba-5f31e9b47067?focus=gene:SPAC2F7.03c&location=I:532245-539744) ([Endpoint](https://dev-2020.ensembl.org/api/metadata/genome/e5a7a144-340f-4455-91ba-5f31e9b47067/karyotype)):
<img width="361" height="434" alt="image" src="https://github.com/user-attachments/assets/9ee92cb3-17ff-4710-8a7b-32227e8b23e9" />

### Knowledge Base
https://embl.atlassian.net/wiki/spaces/EPLATFORM/pages/99024950/Beta+10+REST+API+s+Bug+Report#Missing-chromosome_rank-for-Karyotype-API
