### PR TITLE
Feature/genome group categories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,4 +58,5 @@ dev = [
     "httpx>=0.28.1",
     "pytest>=9.0.2",
     "pytest-benchmark>=5.2.3",
+    "pytest-profiling>=1.8.1",
 ]

--- a/sql/010_create_genome_counts.sql
+++ b/sql/010_create_genome_counts.sql
@@ -79,6 +79,6 @@ from genome_taxonomy_counts where release_id = 0 order by ord;
 .print ''
 from genome_taxonomy_counts where release_id > 0 order by release_id,ord;
 
-#drop table taxonomy_counts;
+drop table taxonomy_counts;
 drop table tax_stop_levels;
 drop macro uptax;

--- a/src/api/models/logic.py
+++ b/src/api/models/logic.py
@@ -476,9 +476,7 @@ def get_brief_genome_details_by_uuid(db_conn, genome_uuid_or_tag, release_versio
         )
 
     if not genome_results:
-        logger.error(
-            f"No Genome/Release found: {genome_uuid_or_tag}/{release_version}"
-        )
+        logger.error(f"No Genome/Release found: {genome_uuid_or_tag}/{release_version}")
         return None
 
     if len(genome_results) > 1:
@@ -1434,14 +1432,43 @@ def data_get_genome_counts(adaptor: MetaAdaptor, release_label: str | None):
         for i in data:
             total += i["count"]
 
-        return {
-            "total": total,
-            "counts": data
-        }
+        return {"total": total, "counts": data}
 
     except Exception:
         logger.exception(
             "Unexpected error while fetching genome counts " "(release_label=%r)",
             release_label,
+        )
+        return None
+
+
+def data_genome_group_categories(adaptor: MetaAdaptor):
+    try:
+        data = adaptor.fetch_genome_groups()
+        genome_group_categories = {}
+        i = 0
+        for entry in data:
+            cat_type = entry["type"]
+            category_entry = genome_group_categories.get(cat_type)
+            if category_entry is None:
+                category_entry = {
+                    "display_name": entry["display_name"],
+                    "type": cat_type,
+                    "groups": [],
+                }
+                genome_group_categories[cat_type] = category_entry
+
+            new_entry["group_id"] = entry["genome_group_id"]
+            new_entry["title"] = entry["label"]
+            new_entry["description"] = entry["description"]
+            new_entry["rank"] = i
+            i += 1
+            new_entry["genomes_count"] = entry["genome_count"]
+            genome_group_categories[cat_type]["groups"].add(new_entry)
+
+        return {"group_categories": genome_group_categories}
+    except Exception:
+        logger.exception(
+            "Unexpected error while fetching genome group categories ",
         )
         return None

--- a/src/api/models/logic.py
+++ b/src/api/models/logic.py
@@ -896,131 +896,119 @@ def get_genome_groups_by_reference(
         not group_type or group_type != "structural_variant"
     ):  # accepting only structural_variant for now
         logger.warning("Missing or Wrong Group type field.")
-        return None
+        raise ValueError("Unsupported group_type")
 
     # The logic calling the ORM and fetching data from the DB
     # will go here, we are returning dummy data for now
     # /!\ Remember to handle the release label
 
-    try:
-        # The logic calling the ORM and fetching data from the DB
-        # will go here. For now, we return dummy data.
+    # The logic calling the ORM and fetching data from the DB
+    # will go here. For now, we return dummy data.
+    dummy_data = [
+        {
+            "group_id": "grch38-group",
+            "group_type": group_type,
+            "group_name": None,
+            "reference_genome": {
+                "genome_uuid": "a7335667-93e7-11ec-a39d-005056b38ce3",
+                "url_name": "grch38",
+                "assembly": {
+                    "accession": "GCA_000001405.29",
+                    "name": "GRCh38.p14",
+                    "ucsc_name": "hg38",
+                    "level": "chromosome",
+                    "ensembl_name": "GRCh38.p14",
+                    "assembly_uuid": "fd7fea38-981a-4d73-a879-6f9daef86f08",
+                    "is_reference": True,
+                },
+                "taxon": {
+                    "taxonomy_id": 9606,
+                    "scientific_name": "Homo sapiens",
+                    "strain": "",
+                    "alternative_names": [],
+                },
+                "created": "2023-09-22 15:04:45",
+                "organism": {
+                    "common_name": "Human",
+                    "strain": "",
+                    "scientific_name": "Homo sapiens",
+                    "ensembl_name": "SAMN12121739",
+                    "scientific_parlance_name": "Human",
+                    "organism_uuid": "1d336185-affe-4a91-85bb-04ebd73cbb56",
+                    "strain_type": None,
+                    "taxonomy_id": 9606,
+                    "species_taxonomy_id": 9606,
+                },
+                "release": {
+                    "release_version": 1,
+                    "release_date": "2025-02-27",
+                    "release_label": "2025-02",
+                    "release_type": "integrated",
+                    "is_current": True,
+                    "site_name": "Ensembl",
+                    "site_label": "MVP ENsembl",
+                    "site_uri": "https://beta.ensembl.org",
+                },
+            },
+        },
+        {
+            "group_id": "t2t-group",
+            "group_type": group_type,
+            "group_name": None,
+            "reference_genome": {
+                "genome_uuid": "4c07817b-c7c5-463f-8624-982286bc4355",
+                "url_name": "t2t-chm13",
+                "assembly": {
+                    "accession": "GCA_009914755.4",
+                    "name": "T2T-CHM13v2.0",
+                    "ucsc_name": "",
+                    "level": "primary_assembly",
+                    "ensembl_name": "T2T-CHM13v2.0",
+                    "assembly_uuid": "fc20ebd6-f756-45da-b941-b3b17e11515f",
+                    "is_reference": False,
+                },
+                "taxon": {
+                    "taxonomy_id": 9606,
+                    "scientific_name": "Homo sapiens",
+                    "strain": "",
+                    "alternative_names": [],
+                },
+                "created": "2023-09-22 15:06:39",
+                "organism": {
+                    "common_name": "Human",
+                    "strain": "",
+                    "scientific_name": "Homo sapiens",
+                    "ensembl_name": "SAMN03255769",
+                    "scientific_parlance_name": "Human",
+                    "organism_uuid": "9df68864-e9fe-4c02-ab8c-8190baad16c6",
+                    "strain_type": None,
+                    "taxonomy_id": 9606,
+                    "species_taxonomy_id": 9606,
+                },
+                "release": {
+                    "release_version": 1,
+                    "release_date": "2025-02-27",
+                    "release_label": "2025-02",
+                    "release_type": "integrated",
+                    "is_current": True,
+                    "site_name": "Ensembl",
+                    "site_label": "MVP ENsembl",
+                    "site_uri": "https://beta.ensembl.org",
+                },
+            },
+        },
+    ]
+
+    # Very simple use of release_label even in dummy mode
+    # TODO: move this filtering into the ORM query once the real implementation is added.
+    if release_label:
         dummy_data = [
-            {
-                "group_id": "grch38-group",
-                "group_type": group_type,
-                "group_name": None,
-                "reference_genome": {
-                    "genome_uuid": "a7335667-93e7-11ec-a39d-005056b38ce3",
-                    "url_name": "grch38",
-                    "assembly": {
-                        "accession": "GCA_000001405.29",
-                        "name": "GRCh38.p14",
-                        "ucsc_name": "hg38",
-                        "level": "chromosome",
-                        "ensembl_name": "GRCh38.p14",
-                        "assembly_uuid": "fd7fea38-981a-4d73-a879-6f9daef86f08",
-                        "is_reference": True,
-                    },
-                    "taxon": {
-                        "taxonomy_id": 9606,
-                        "scientific_name": "Homo sapiens",
-                        "strain": "",
-                        "alternative_names": [],
-                    },
-                    "created": "2023-09-22 15:04:45",
-                    "organism": {
-                        "common_name": "Human",
-                        "strain": "",
-                        "scientific_name": "Homo sapiens",
-                        "ensembl_name": "SAMN12121739",
-                        "scientific_parlance_name": "Human",
-                        "organism_uuid": "1d336185-affe-4a91-85bb-04ebd73cbb56",
-                        "strain_type": None,
-                        "taxonomy_id": 9606,
-                        "species_taxonomy_id": 9606,
-                    },
-                    "release": {
-                        "release_version": 1,
-                        "release_date": "2025-02-27",
-                        "release_label": "2025-02",
-                        "release_type": "integrated",
-                        "is_current": True,
-                        "site_name": "Ensembl",
-                        "site_label": "MVP ENsembl",
-                        "site_uri": "https://beta.ensembl.org",
-                    },
-                },
-            },
-            {
-                "group_id": "t2t-group",
-                "group_type": group_type,
-                "group_name": None,
-                "reference_genome": {
-                    "genome_uuid": "4c07817b-c7c5-463f-8624-982286bc4355",
-                    "url_name": "t2t-chm13",
-                    "assembly": {
-                        "accession": "GCA_009914755.4",
-                        "name": "T2T-CHM13v2.0",
-                        "ucsc_name": "",
-                        "level": "primary_assembly",
-                        "ensembl_name": "T2T-CHM13v2.0",
-                        "assembly_uuid": "fc20ebd6-f756-45da-b941-b3b17e11515f",
-                        "is_reference": False,
-                    },
-                    "taxon": {
-                        "taxonomy_id": 9606,
-                        "scientific_name": "Homo sapiens",
-                        "strain": "",
-                        "alternative_names": [],
-                    },
-                    "created": "2023-09-22 15:06:39",
-                    "organism": {
-                        "common_name": "Human",
-                        "strain": "",
-                        "scientific_name": "Homo sapiens",
-                        "ensembl_name": "SAMN03255769",
-                        "scientific_parlance_name": "Human",
-                        "organism_uuid": "9df68864-e9fe-4c02-ab8c-8190baad16c6",
-                        "strain_type": None,
-                        "taxonomy_id": 9606,
-                        "species_taxonomy_id": 9606,
-                    },
-                    "release": {
-                        "release_version": 1,
-                        "release_date": "2025-02-27",
-                        "release_label": "2025-02",
-                        "release_type": "integrated",
-                        "is_current": True,
-                        "site_name": "Ensembl",
-                        "site_label": "MVP ENsembl",
-                        "site_uri": "https://beta.ensembl.org",
-                    },
-                },
-            },
+            g
+            for g in dummy_data
+            if g["reference_genome"]["release"]["release_label"] == release_label
         ]
 
-        # Very simple use of release_label even in dummy mode
-        # TODO: move this filtering into the ORM query once the real implementation is added.
-        if release_label:
-            dummy_data = [
-                g
-                for g in dummy_data
-                if g["reference_genome"]["release"]["release_label"] == release_label
-            ]
-
-        return {"genome_groups": dummy_data}
-
-    except Exception:
-        # Dummy error handling until the real ORM logic is in place
-        logger.exception(
-            "Unexpected error while fetching genome groups "
-            "(group_type=%r, release_label=%r)",
-            group_type,
-            release_label,
-        )
-        # Return an empty message to avoid propagating the error to callers.
-        return None
+    return {"genome_groups": dummy_data}
 
 
 # Dummy methods as found in upstream. Need to be properly connected to DB
@@ -1410,50 +1398,35 @@ def data_get_genomes_in_group(
 
 
 def data_get_genome_counts(adaptor: MetaAdaptor, release_label: str | None):
+    data = adaptor.fetch_genome_taxonomy_counts(release_label)
+    total = 0
+    for i in data:
+        total += i["count"]
 
-    try:
-        data = adaptor.fetch_genome_taxonomy_counts(release_label)
-        total = 0
-        for i in data:
-            total += i["count"]
-
-        return {"total": total, "counts": data}
-
-    except Exception:
-        logger.exception(
-            "Unexpected error while fetching genome counts " "(release_label=%r)",
-            release_label,
-        )
-        return None
+    return {"total": total, "counts": data}
 
 
 def data_genome_group_categories(adaptor: MetaAdaptor):
-    try:
-        data = adaptor.fetch_genome_groups()
-        genome_group_categories = {}
-        for entry in data:
-            cat_type = entry["type"]
-            category_entry = genome_group_categories.get(cat_type)
-            if category_entry is None:
-                category_entry = {
-                    "display_name": entry["display_name"],
-                    "type": cat_type,
-                    "groups": [],
-                }
-                genome_group_categories[cat_type] = category_entry
-
-            new_entry = {
-                "group_id": entry["genome_group_id"],
-                "title": entry["label"],
-                "description": entry["description"],
-                "rank": len(category_entry["groups"]) + 1,
-                "genomes_count": entry["genome_count"],
+    data = adaptor.fetch_genome_groups()
+    genome_group_categories = {}
+    for entry in data:
+        cat_type = entry["type"]
+        category_entry = genome_group_categories.get(cat_type)
+        if category_entry is None:
+            category_entry = {
+                "display_name": entry["display_name"],
+                "type": cat_type,
+                "groups": [],
             }
-            category_entry["groups"].append(new_entry)
+            genome_group_categories[cat_type] = category_entry
 
-        return {"group_categories": list(genome_group_categories.values())}
-    except Exception:
-        logger.exception(
-            "Unexpected error while fetching genome group categories ",
-        )
-        return None
+        new_entry = {
+            "group_id": entry["genome_group_id"],
+            "title": entry["label"],
+            "description": entry["description"],
+            "rank": len(category_entry["groups"]) + 1,
+            "genomes_count": entry["genome_count"],
+        }
+        category_entry["groups"].append(new_entry)
+
+    return {"group_categories": list(genome_group_categories.values())}

--- a/src/api/models/logic.py
+++ b/src/api/models/logic.py
@@ -1431,7 +1431,6 @@ def data_genome_group_categories(adaptor: MetaAdaptor):
     try:
         data = adaptor.fetch_genome_groups()
         genome_group_categories = {}
-        i = 0
         for entry in data:
             cat_type = entry["type"]
             category_entry = genome_group_categories.get(cat_type)
@@ -1443,15 +1442,16 @@ def data_genome_group_categories(adaptor: MetaAdaptor):
                 }
                 genome_group_categories[cat_type] = category_entry
 
-            new_entry["group_id"] = entry["genome_group_id"]
-            new_entry["title"] = entry["label"]
-            new_entry["description"] = entry["description"]
-            new_entry["rank"] = i
-            i += 1
-            new_entry["genomes_count"] = entry["genome_count"]
-            genome_group_categories[cat_type]["groups"].add(new_entry)
+            new_entry = {
+                "group_id": entry["genome_group_id"],
+                "title": entry["label"],
+                "description": entry["description"],
+                "rank": len(category_entry["groups"]) + 1,
+                "genomes_count": entry["genome_count"],
+            }
+            category_entry["groups"].append(new_entry)
 
-        return {"group_categories": genome_group_categories}
+        return {"group_categories": list(genome_group_categories.values())}
     except Exception:
         logger.exception(
             "Unexpected error while fetching genome group categories ",

--- a/src/api/models/meta_adaptor.py
+++ b/src/api/models/meta_adaptor.py
@@ -16,8 +16,9 @@ from typing import List
 
 import sqlalchemy as db
 from ensembl.utils.database import DBConnection
+from ensembl.production.metadata.api.models.genome import Genome
 
-from sqlalchemy import Column, Integer, create_engine, Index, ForeignKey
+from sqlalchemy import Column, Integer, create_engine, Index, ForeignKey, func
 from sqlalchemy.orm import DeclarativeBase, relationship, declarative_base
 from sqlalchemy.orm.session import Session
 
@@ -29,12 +30,32 @@ logger = logging.getLogger(__name__)
 class Base(DeclarativeBase):
     pass
 
+
 class GenomeTaxonomyCounts(DeferredReflection, Base):
-    __tablename__ = 'genome_taxonomy_counts'
-    __table_args__ = {'extend_existing': True}
+    __tablename__ = "genome_taxonomy_counts"
+    __table_args__ = {"extend_existing": True}
     genome_id = Column(Integer, primary_key=True)
 
-class MetaAdaptor():
+
+class GenomeGroup(DeferredReflection, Base):
+    __tablename__ = "genome_group"
+    __table_args__ = {"extend_existing": True}
+    genome_group_id = Column(Integer, primary_key=True)
+
+
+class GenomeGroupMember(DeferredReflection, Base):
+    __tablename__ = "genome_group_member"
+    __table_args__ = {"extend_existing": True}
+    genome_group_member_id = Column(Integer, primary_key=True)
+
+
+class GenomeGroupCategory(DeferredReflection, Base):
+    __tablename__ = "genome_group_category"
+    __table_args__ = {"extend_existing": True}
+    genome_group_category_id = Column(Integer, primary_key=True)
+
+
+class MetaAdaptor:
     db_conn: DBConnection = None
 
     def __init__(self, db_conn: DBConnection):
@@ -46,7 +67,7 @@ class MetaAdaptor():
         Fetches genome taxonomy counts.
 
         Args:
-            None
+            release_label: A release label, e.g. 2026-02
 
         Returns:
             List[Tuple[str, int]]: A list of tuples containing the fetched information.
@@ -59,12 +80,83 @@ class MetaAdaptor():
             genome_taxonomy_counts = fetch_genome_taxonomy_counts()
         """
         if release_label == None:
-            release_label = ''
+            release_label = ""
         with self.db_conn.session_scope() as session:
-            sql = db.select(
-                GenomeTaxonomyCounts.ensembl_taxon_name,
-                GenomeTaxonomyCounts.count,
-            ).where(GenomeTaxonomyCounts.label == release_label).order_by(GenomeTaxonomyCounts.ord)
+            sql = (
+                db.select(
+                    GenomeTaxonomyCounts.ensembl_taxon_name,
+                    GenomeTaxonomyCounts.count,
+                )
+                .where(GenomeTaxonomyCounts.label == release_label)
+                .order_by(GenomeTaxonomyCounts.ord)
+            )
             logger.debug(sql)
             genome_taxonomy_counts = session.execute(sql).mappings().all()
         return genome_taxonomy_counts
+
+    def fetch_genome_groups(self):
+        """
+        Fetches genome groups.
+
+        Args:
+            None
+
+        Returns:
+            List[GenomeGroup]: A list of GenomeGroup objects
+
+        Example usage:
+            genome_groups = fetch_genome_groups()
+        """
+        # select display_name, gg.type, gg.genome_group_id, name, label, description, count(genome_id) as genome_count
+        # from genome_group gg
+        # inner join genome_group_member gm on gm.genome_group_id = gg.genome_group_id
+        # inner join genome_group_category gc on gc.type = gg.type
+        # where gg.genome_group_id = 13 group by all;
+
+        with self.db_conn.session_scope() as session:
+            sql = (
+                db.select(
+                    GenomeGroup.type,
+                    GenomeGroup.genome_group_id,
+                    GenomeGroup.name,
+                    GenomeGroup.label,
+                    GenomeGroup.description,
+                    GenomeGroupCategory.display_name,
+                    func.count(GenomeGroupMember.genome_id).label("genome_count"),
+                )
+                .join(
+                    GenomeGroupMember,
+                    GenomeGroupMember.genome_group_id == GenomeGroup.genome_group_id,
+                )
+                .join(GenomeGroupCategory, GenomeGroupCategory.type == GenomeGroup.type)
+                .group_by(
+                    GenomeGroup.type,
+                    GenomeGroup.genome_group_id,
+                    GenomeGroup.name,
+                    GenomeGroup.label,
+                    GenomeGroup.description,
+                    GenomeGroupCategory.display_name,
+                )
+                .order_by(GenomeGroup.genome_group_id)
+            )
+            logger.debug(sql)
+            genome_groups = session.execute(sql).mappings().all()
+        return genome_groups
+
+    def fetch_genome_group_members(self, group_id: int):
+        if group_id is None:
+            raise ValueError
+
+        with self.db_conn.session_scope() as session:
+            sql = (
+                db.select(Genome.genome_uuid)
+                .join(
+                    GenomeGroupMember, Genome.genome_id == GenomeGroupMember.genome_id
+                )
+                .where(GenomeGroupMember.genome_group_id == group_id)
+                .order_by(Genome.genome_uuid)
+            )
+            logger.debug(sql)
+            data = session.execute(sql).mappings().all()
+
+        return data

--- a/src/api/models/meta_adaptor.py
+++ b/src/api/models/meta_adaptor.py
@@ -49,18 +49,33 @@ class GenomeGroupMember(DeferredReflection, Base):
     genome_group_member_id = Column(Integer, primary_key=True)
 
 
-class GenomeGroupCategory(DeferredReflection, Base):
-    __tablename__ = "genome_group_category"
-    __table_args__ = {"extend_existing": True}
-    genome_group_category_id = Column(Integer, primary_key=True)
-
-
 class MetaAdaptor:
     db_conn: DBConnection = None
 
     def __init__(self, db_conn: DBConnection):
         self.db_conn = db_conn
         DeferredReflection.prepare(db_conn._engine)
+
+    @staticmethod
+    def _genome_group_category_mock():
+        # Temporary replacement until genome_group_category exists in metadata DB.
+        return (
+            db.select(
+                db.literal(1).label("genome_group_category_id"),
+                db.literal("collection").label("type"),
+                db.literal("Ensembl genome collections").label("display_name"),
+                db.literal(1).label("ggc_order"),
+            )
+            .union_all(
+                db.select(
+                    db.literal(2).label("genome_group_category_id"),
+                    db.literal("project").label("type"),
+                    db.literal("External projects").label("display_name"),
+                    db.literal(2).label("ggc_order"),
+                )
+            )
+            .subquery("genome_group_category")
+        )
 
     def fetch_genome_taxonomy_counts(self, release_label: str | None = None):
         """
@@ -114,6 +129,7 @@ class MetaAdaptor:
         # where gg.genome_group_id = 13 group by all;
 
         with self.db_conn.session_scope() as session:
+            genome_group_category = self._genome_group_category_mock()
             sql = (
                 db.select(
                     GenomeGroup.type,
@@ -121,23 +137,26 @@ class MetaAdaptor:
                     GenomeGroup.name,
                     GenomeGroup.label,
                     GenomeGroup.description,
-                    GenomeGroupCategory.display_name,
+                    genome_group_category.c.display_name,
                     func.count(GenomeGroupMember.genome_id).label("genome_count"),
                 )
                 .join(
                     GenomeGroupMember,
                     GenomeGroupMember.genome_group_id == GenomeGroup.genome_group_id,
                 )
-                .join(GenomeGroupCategory, GenomeGroupCategory.type == GenomeGroup.type)
+                .join(genome_group_category, genome_group_category.c.type == GenomeGroup.type)
                 .group_by(
                     GenomeGroup.type,
                     GenomeGroup.genome_group_id,
                     GenomeGroup.name,
                     GenomeGroup.label,
                     GenomeGroup.description,
-                    GenomeGroupCategory.display_name,
+                    genome_group_category.c.display_name,
+                    genome_group_category.c.ggc_order,
                 )
-                .order_by(GenomeGroup.genome_group_id)
+                .order_by(
+                    genome_group_category.c.ggc_order, GenomeGroup.genome_group_id
+                )
             )
             logger.debug(sql)
             genome_groups = session.execute(sql).mappings().all()

--- a/src/api/resources/routes.py
+++ b/src/api/resources/routes.py
@@ -15,19 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-# import enum
-import itertools
 import logging
 
 from api.logconfig import InterceptHandler
-import os
-
-# import pytest
-# import sqlalchemy
-# import time
-import timeit
-import uuid
-from datetime import datetime
 
 from typing import Annotated, Any
 
@@ -58,8 +48,6 @@ from api.schemas.vep import VepFilePaths
 from api.resources.redis import redis_cache
 from api.dependencies import Dependencies
 
-# get_genome_adaptor, get_vep_adaptor, get_release_adaptor
-
 from ensembl.production.metadata.api.adaptors import GenomeAdaptor, ReleaseAdaptor
 from ensembl.production.metadata.api.adaptors.vep import VepAdaptor
 from api.models.meta_adaptor import MetaAdaptor
@@ -81,30 +69,13 @@ logger.info("Starting up")
 from api.models.logic import (
     get_top_level_statistics_by_uuid,
     get_top_level_regions,
-    assembly_region_iterator,
-    create_assembly_region,
     get_organisms_group_count,
-    create_organisms_group_count,
     get_attributes_by_genome_uuid,
-    create_attributes_info,
     get_genome_by_uuid,
-    create_genome_with_attributes_and_count,
-    get_alternative_names,
-    create_genome,
-    create_assembly,
-    create_taxon,
-    create_organism,
-    create_release,
     get_ftp_links,
-    create_paths,
     get_brief_genome_details_by_uuid,
-    is_valid_uuid,
-    create_brief_genome_details,
     genome_assembly_sequence_region,
-    create_genome_assembly_sequence_region,
     get_dataset_attributes,
-    get_attributes_values_by_uuid,
-    create_attribute_value,
     get_genomes_by_specific_keyword_iterator,
     get_vep_paths_by_uuid,
     release_iterator,
@@ -154,20 +125,16 @@ async def get_genome_karyotype(
 @router.get("/popular_species", name="popular_species")
 @redis_cache(key_prefix="popular_species")  # TTL defaults is 5 minutes
 async def get_popular_species(adaptor: GenomeAdaptorDep, request: Request):
-    #    try:
-    popular_species_dict = get_organisms_group_count(adaptor, None)
-    #        logger.error(popular_species_dict)
-    logger.error(popular_species_dict["organisms_group_count"][23])
-    popular_species = popular_species_dict["organisms_group_count"]
-    popular_species_response = PopularSpeciesGroup(
-        _base_url=request.headers["host"], popular_species=popular_species
-    )
-    return responses.JSONResponse(popular_species_response.model_dump())
-
-
-#    except Exception as e:
-#        logging.error(e)
-#        return response_error_handler({"status": 500})
+    try:
+        popular_species_dict = get_organisms_group_count(adaptor, None)
+        popular_species = popular_species_dict["organisms_group_count"]
+        popular_species_response = PopularSpeciesGroup(
+            _base_url=request.headers["host"], popular_species=popular_species
+        )
+        return responses.JSONResponse(popular_species_response.model_dump())
+    except Exception as e:
+        logging.error(e)
+        return response_error_handler({"status": 500})
 
 
 @router.get("/validate_location", name="validate_location")
@@ -466,7 +433,7 @@ async def get_genome_groups(
             adaptor, group_type, release
         )
         logger.debug(f"genome_groups_dict: {genome_groups_dict}")
-        if len(genome_groups_dict.get("genome_groups", [])) == 0:
+        if not genome_groups_dict:
             return response_error_handler(
                 {"status": 404, "details": "No genome groups found matching criteria"}
             )
@@ -491,7 +458,7 @@ async def get_genomes_in_group(
     try:
         genomes_in_group_dict = data_get_genomes_in_group(adaptor, group_id, release)
         logger.debug(f"genomes_in_group_dict: {genomes_in_group_dict}")
-        if len(genomes_in_group_dict.get("genomes", [])) == 0:
+        if not genomes_in_group_dict:
             return response_error_handler(
                 {"status": 404, "details": "No genomes found in specified group"}
             )

--- a/src/api/resources/routes.py
+++ b/src/api/resources/routes.py
@@ -433,15 +433,13 @@ async def get_genome_groups(
             adaptor, group_type, release
         )
         logger.debug(f"genome_groups_dict: {genome_groups_dict}")
-        if not genome_groups_dict:
-            return response_error_handler(
-                {"status": 404, "details": "No genome groups found matching criteria"}
-            )
-
         genome_groups = GenomeGroupsResponse(**genome_groups_dict)
         response_dict = genome_groups.model_dump()
         return responses.JSONResponse(response_dict, status_code=200)
-    except Exception as ex:
+    except ValueError as ex:
+        logger.warning("Invalid request in get_genome_groups: %s", ex)
+        return response_error_handler({"status": 400, "details": str(ex)})
+    except Exception:
         logger.exception("Error in get_genome_groups")
         return response_error_handler({"status": 500})
 
@@ -479,10 +477,16 @@ async def get_genome_counts(
         None, description="Optional release label to filter counts, e.g. '2025-02'"
     ),
 ):
-    genome_counts_dict = data_get_genome_counts(adaptor, release)
-    genome_counts = GenomeCountsResponse(**genome_counts_dict)
-    response_data = responses.JSONResponse(genome_counts.model_dump(), status_code=200)
-    return response_data
+    try:
+        genome_counts_dict = data_get_genome_counts(adaptor, release)
+        genome_counts = GenomeCountsResponse(**genome_counts_dict)
+        response_data = responses.JSONResponse(
+            genome_counts.model_dump(), status_code=200
+        )
+        return response_data
+    except Exception:
+        logger.exception("Error in get_genome_counts (release=%r)", release)
+        return response_error_handler({"status": 500})
 
 
 @router.get("/genome_group_categories", name="genome_group_categories")
@@ -490,10 +494,14 @@ async def get_genome_counts(
 async def get_genome_group_categories(
     adaptor: MetaAdaptorDep,
 ):
-    group_dict = data_genome_group_categories(adaptor)
-    logger.debug(f"group_dict: {group_dict}")
-    genome_group_categories = GenomeGroupCategoriesResponse(**group_dict)
-    response_data = responses.JSONResponse(
-        genome_group_categories.model_dump(), status_code=200
-    )
-    return response_data
+    try:
+        group_dict = data_genome_group_categories(adaptor)
+        logger.debug(f"group_dict: {group_dict}")
+        genome_group_categories = GenomeGroupCategoriesResponse(**group_dict)
+        response_data = responses.JSONResponse(
+            genome_group_categories.model_dump(), status_code=200
+        )
+        return response_data
+    except Exception:
+        logger.exception("Error in get_genome_group_categories")
+        return response_error_handler({"status": 500})

--- a/src/api/resources/routes.py
+++ b/src/api/resources/routes.py
@@ -47,6 +47,7 @@ from api.schemas.genome import (
     GenomeGroupsResponse,
     GenomesInGroupResponse,
     GenomeCountsResponse,
+    GenomeGroupCategoriesResponse,
 )
 from api.schemas.karyotype import Karyotype
 from api.schemas.popular_species import PopularSpeciesGroup
@@ -524,7 +525,7 @@ async def get_genome_group_categories(
 ):
     group_dict = data_genome_group_categories(adaptor)
     logger.debug(f"group_dict: {group_dict}")
-    genome_group_categories = GenomeGroupCategories(**group_dict)
+    genome_group_categories = GenomeGroupCategoriesResponse(**group_dict)
     response_data = responses.JSONResponse(
         genome_group_categories.model_dump(), status_code=200
     )

--- a/src/api/resources/routes.py
+++ b/src/api/resources/routes.py
@@ -110,6 +110,7 @@ from api.models.logic import (
     get_genome_groups_by_reference,
     data_get_genomes_in_group,
     data_get_genome_counts,
+    data_genome_group_categories,
 )
 
 
@@ -152,16 +153,20 @@ async def get_genome_karyotype(
 @router.get("/popular_species", name="popular_species")
 @redis_cache(key_prefix="popular_species")  # TTL defaults is 5 minutes
 async def get_popular_species(adaptor: GenomeAdaptorDep, request: Request):
-    try:
-        popular_species_dict = get_organisms_group_count(adaptor, None)
-        popular_species = popular_species_dict["organisms_group_count"]
-        popular_species_response = PopularSpeciesGroup(
-            _base_url=request.headers["host"], popular_species=popular_species
-        )
-        return responses.JSONResponse(popular_species_response.model_dump())
-    except Exception as e:
-        logging.error(e)
-        return response_error_handler({"status": 500})
+    #    try:
+    popular_species_dict = get_organisms_group_count(adaptor, None)
+    #        logger.error(popular_species_dict)
+    logger.error(popular_species_dict["organisms_group_count"][23])
+    popular_species = popular_species_dict["organisms_group_count"]
+    popular_species_response = PopularSpeciesGroup(
+        _base_url=request.headers["host"], popular_species=popular_species
+    )
+    return responses.JSONResponse(popular_species_response.model_dump())
+
+
+#    except Exception as e:
+#        logging.error(e)
+#        return response_error_handler({"status": 500})
 
 
 @router.get("/validate_location", name="validate_location")
@@ -389,7 +394,9 @@ async def get_vep_file_paths(
             )
 
         vep_file_paths_object = VepFilePaths(**vep_file_paths)
-        return responses.JSONResponse(vep_file_paths_object.model_dump(), status_code=200)
+        return responses.JSONResponse(
+            vep_file_paths_object.model_dump(), status_code=200
+        )
 
     except Exception as ex:
         logger.error(ex)
@@ -504,7 +511,19 @@ async def get_genome_counts(
 ):
     genome_counts_dict = data_get_genome_counts(adaptor, release)
     genome_counts = GenomeCountsResponse(**genome_counts_dict)
+    response_data = responses.JSONResponse(genome_counts.model_dump(), status_code=200)
+    return response_data
+
+
+@router.get("/genome_group_categories", name="genome_group_categories")
+@redis_cache(key_prefix="genome_group_categories")
+async def get_genome_group_categories(
+    adaptor: MetaAdaptorDep,
+):
+    group_dict = data_genome_group_categories(adaptor)
+    logger.debug(f"group_dict: {group_dict}")
+    genome_group_categories = GenomeGroupCategories(**group_dict)
     response_data = responses.JSONResponse(
-        genome_counts.model_dump(), status_code=200
+        genome_group_categories.model_dump(), status_code=200
     )
     return response_data

--- a/src/api/schemas/genome.py
+++ b/src/api/schemas/genome.py
@@ -203,7 +203,7 @@ class GenomeByKeyword(BaseModel):
     genome_tag: str = Field(alias=AliasPath("genome", "url_name"), default="")
 
 
-class GenomeGroup(BaseModel):
+class AlignmentViewerGenomeGroup(BaseModel):
     id: str = Field(alias="group_id")
     type: str = Field(alias="group_type")
     name: str | None = Field(alias="group_name", default=None)
@@ -211,7 +211,7 @@ class GenomeGroup(BaseModel):
 
 
 class GenomeGroupsResponse(BaseModel):
-    genome_groups: list[GenomeGroup] = Field(alias="genome_groups")
+    genome_groups: list[AlignmentViewerGenomeGroup] = Field(alias="genome_groups")
 
 
 class GenomesInGroupResponse(BaseModel):
@@ -228,7 +228,7 @@ class GenomeCountsResponse(BaseModel):
     counts: list[GenomeCountItem] = Field(default_factory=list)
 
 
-class GenomeGroupCategoryGroup(BaseModel):
+class GenomeGroup(BaseModel):
     group_id: int
     title: str
     description: str | None = None
@@ -239,7 +239,7 @@ class GenomeGroupCategoryGroup(BaseModel):
 class GenomeGroupCategory(BaseModel):
     display_name: str
     type: str
-    groups: list[GenomeGroupCategoryGroup] = Field(default_factory=list)
+    groups: list[GenomeGroup] = Field(default_factory=list)
 
 
 class GenomeGroupCategoriesResponse(BaseModel):

--- a/src/api/schemas/genome.py
+++ b/src/api/schemas/genome.py
@@ -226,3 +226,21 @@ class GenomeCountItem(BaseModel):
 class GenomeCountsResponse(BaseModel):
     total: int = 0
     counts: list[GenomeCountItem] = Field(default_factory=list)
+
+
+class GenomeGroupCategoryGroup(BaseModel):
+    group_id: int
+    title: str
+    description: str | None = None
+    rank: int
+    genomes_count: int
+
+
+class GenomeGroupCategory(BaseModel):
+    display_name: str
+    type: str
+    groups: list[GenomeGroupCategoryGroup] = Field(default_factory=list)
+
+
+class GenomeGroupCategoriesResponse(BaseModel):
+    group_categories: list[GenomeGroupCategory] = Field(default_factory=list)

--- a/src/ensembl/utils/__init__.py
+++ b/src/ensembl/utils/__init__.py
@@ -23,5 +23,4 @@ __all__ = [
 import os
 from typing import TypeVar
 
-
 StrPath = TypeVar("StrPath", str, os.PathLike)

--- a/src/ensembl/utils/database/dbconnection.py
+++ b/src/ensembl/utils/database/dbconnection.py
@@ -47,7 +47,12 @@ from sqlalchemy.schema import MetaData, Table
 
 import logging
 
-Query = TypeVar("Query", str, sqlalchemy.sql.expression.ClauseElement, sqlalchemy.sql.expression.TextClause)
+Query = TypeVar(
+    "Query",
+    str,
+    sqlalchemy.sql.expression.ClauseElement,
+    sqlalchemy.sql.expression.TextClause,
+)
 StrURL = TypeVar("StrURL", str, sqlalchemy.engine.URL)
 
 

--- a/tests/api/models/test_meta_adaptor.py
+++ b/tests/api/models/test_meta_adaptor.py
@@ -19,7 +19,6 @@ from api.config import DB_URL
 from ensembl.utils.database import DBConnection
 import logging
 
-
 meta_conn = DBConnection(
     DB_URL, connect_args={"read_only": True, "config": {"memory_limit": "1GB"}}
 )
@@ -29,12 +28,12 @@ adaptor = MetaAdaptor(meta_conn)
 def test_get_genome_counts():
     data = adaptor.fetch_genome_taxonomy_counts()
     assert data == [
-       {'ensembl_taxon_name': 'Animals', 'count': 4207},
-       {'ensembl_taxon_name': 'Archaea', 'count': 24},
-       {'ensembl_taxon_name': 'Bacteria', 'count': 85},
-       {'ensembl_taxon_name': 'Fungi', 'count': 153},
-       {'ensembl_taxon_name': 'Green Plants', 'count': 465},
-       {'ensembl_taxon_name': 'Others', 'count': 43},
+        {"ensembl_taxon_name": "Animals", "count": 4207},
+        {"ensembl_taxon_name": "Archaea", "count": 24},
+        {"ensembl_taxon_name": "Bacteria", "count": 85},
+        {"ensembl_taxon_name": "Fungi", "count": 153},
+        {"ensembl_taxon_name": "Green Plants", "count": 465},
+        {"ensembl_taxon_name": "Others", "count": 43},
     ]
 
     data = adaptor.fetch_genome_taxonomy_counts("2026-01-26")
@@ -45,6 +44,105 @@ def test_get_genome_counts():
         {"ensembl_taxon_name": "Others", "count": 2},
     ]
 
+
 def test_get_genome_groups():
     data = adaptor.fetch_genome_groups()
-    assert data == []
+    assert data == [
+        {
+            "type": "project",
+            "genome_group_id": 12,
+            "name": "vgp",
+            "label": "Vertebrate Genomes Project (VGP)",
+            "description": "The Vertebrate Genomes Project (VGP) is an international effort to generate near error-free, high-quality reference genome assemblies for all ~70,000 extant vertebrate species, advancing biology, conservation, and disease research.",
+            "display_name": "External projects",
+            "genome_count": 399,
+        },
+        {
+            "type": "project",
+            "genome_group_id": 13,
+            "name": "erga-bge",
+            "label": "Biodiversity Genomics Europe (BGE)",
+            "description": "The ERGA-BGE project accelerates genomic science across Europe by generating high-quality reference genomes for biodiversity, supporting conservation, monitoring, and research as part of the Biodiversity Genomics Europe and Earth BioGenome initiatives.",
+            "display_name": "External projects",
+            "genome_count": 63,
+        },
+        {
+            "type": "project",
+            "genome_group_id": 14,
+            "name": "aegis",
+            "label": "Ancient Environmental Genomics Initiative for Sustainability (AEGIS)",
+            "description": "AEGIS is a global research consortium using ancient environmental DNA and genomics to uncover past adaptations and genetic diversity, guiding development of climate-resilient crops and sustainable food systems under climate change.",
+            "display_name": "External projects",
+            "genome_count": 79,
+        },
+    ]
+
+
+def test_get_genome_group_members():
+
+    data = adaptor.fetch_genome_group_members(13)
+    assert data == [
+        {"genome_uuid": "085584f1-be77-4fd8-bb4b-55179438a77a"},
+        {"genome_uuid": "0e692343-7207-4e4d-ae06-46327e0884b1"},
+        {"genome_uuid": "0f03bee1-bdb9-4b0f-8fa4-4162d6fc4de0"},
+        {"genome_uuid": "15dfef38-da6b-4090-9ba9-501272a54d72"},
+        {"genome_uuid": "183fb547-fe4f-483f-93a6-33e806d8ffb4"},
+        {"genome_uuid": "18cdfb34-0079-41ba-b551-0610d98a869e"},
+        {"genome_uuid": "199ac9d9-9a12-42fe-ad46-ab919e1b7ea1"},
+        {"genome_uuid": "1cd65d9f-f9c9-480b-8827-332c97d3a7e1"},
+        {"genome_uuid": "20a32d3c-c6e5-4c72-9fed-223c3fcc7cce"},
+        {"genome_uuid": "24c3b588-6437-4aef-b00d-97f1ff6db8c3"},
+        {"genome_uuid": "2d09ff5e-5f83-4ead-af26-883f2aa90049"},
+        {"genome_uuid": "2d6feac9-68ca-475a-b26a-e543f5617f7c"},
+        {"genome_uuid": "2dce4529-d5c5-4380-90bb-fc9a93b14e26"},
+        {"genome_uuid": "311af7cc-7b06-4af1-b7f0-a479530494e9"},
+        {"genome_uuid": "3a017399-fbdd-4f75-a766-ddd353a23e61"},
+        {"genome_uuid": "3dc4ba1b-5b1a-4788-8903-abb54df65971"},
+        {"genome_uuid": "3e668946-a16d-49d7-af96-a6fa00aa9c95"},
+        {"genome_uuid": "460b29ed-3ce3-4461-bd5e-4094a5e65d30"},
+        {"genome_uuid": "4a1f953e-fcc1-4772-aae5-a7d85f896adf"},
+        {"genome_uuid": "4cb15167-5eba-4a0e-89ff-ed7526a3b475"},
+        {"genome_uuid": "4d0d28ca-9dd8-449b-8938-554fd1927dcb"},
+        {"genome_uuid": "4fa77dd7-1ef3-43b6-b715-da7a5b1d2a4b"},
+        {"genome_uuid": "5150ca1a-c085-49c1-8aeb-236bece9e2ac"},
+        {"genome_uuid": "589ab9de-b4d3-4060-98a9-bd6f49b8165d"},
+        {"genome_uuid": "61650ef3-65c0-4f37-9695-59bde3ddda4c"},
+        {"genome_uuid": "624c4e99-7b00-4998-ab74-3299c4f791f4"},
+        {"genome_uuid": "66abcf9f-42d0-4c7c-b6ae-fa8a39409d1b"},
+        {"genome_uuid": "693b2899-2c0f-4a7b-8911-f52bb911c014"},
+        {"genome_uuid": "773a6911-caee-4048-abe8-1be3bacf309e"},
+        {"genome_uuid": "7b06a885-ead8-41aa-a36f-4af2ad43f6ff"},
+        {"genome_uuid": "7f7df65a-cad2-4df3-a691-562103c3823c"},
+        {"genome_uuid": "831f67ca-ad59-42db-97cf-2928163ba54c"},
+        {"genome_uuid": "84d8aa9e-1f9e-40fe-a304-b3d2d5df1e9a"},
+        {"genome_uuid": "8f02da11-38b0-4ce4-b9ff-44225adee5dc"},
+        {"genome_uuid": "9059f588-83b9-4ab7-9dc5-1f121a6ac612"},
+        {"genome_uuid": "92536bc5-9610-49d2-9d34-7bc93725e4c7"},
+        {"genome_uuid": "9411dc39-a79c-444f-876f-8ded9239c07f"},
+        {"genome_uuid": "a427b035-c8f5-4af1-b960-75177cbbbd8d"},
+        {"genome_uuid": "a45e488b-c465-4bf4-9cf8-e40037ad3323"},
+        {"genome_uuid": "ae315f68-16f6-493a-848b-16b381ea7c0e"},
+        {"genome_uuid": "af787540-14c0-47e4-a5fa-d737ae99dd3f"},
+        {"genome_uuid": "b06623a7-bd90-417a-9225-3a017a9e95f5"},
+        {"genome_uuid": "b226bf95-1cf3-49ee-b653-1f5579aaa4e9"},
+        {"genome_uuid": "b5224c43-5760-4ecc-8d70-8aa1cc1309ab"},
+        {"genome_uuid": "b5c4a1a3-34b1-41ca-a06a-b0b1184f6eb2"},
+        {"genome_uuid": "ba159eac-8428-4dd6-b0a7-35dad962cbea"},
+        {"genome_uuid": "bd6e4578-1a73-4347-86e9-be824786e8ca"},
+        {"genome_uuid": "c1090fd6-893b-4184-8896-13303cade69c"},
+        {"genome_uuid": "daa9ab30-f5e7-45ad-9b7d-bb00e36d9014"},
+        {"genome_uuid": "db285f3a-bbd6-454d-9908-b199da23d63b"},
+        {"genome_uuid": "dd75a185-ff90-4c98-93c1-2a820123a452"},
+        {"genome_uuid": "deaa01f4-be70-4e6e-b2a4-9d3c1aa54f92"},
+        {"genome_uuid": "e63807d3-ebd9-443b-9615-51777ada1392"},
+        {"genome_uuid": "e99525f8-b109-4002-974e-54dbab524cb3"},
+        {"genome_uuid": "eabb8e38-7401-4fb6-8a26-2e3e4b92cb84"},
+        {"genome_uuid": "eb483ac2-9422-4142-82d4-087b75623a5b"},
+        {"genome_uuid": "ef8c4346-d4f4-4a5e-b91f-e27817698392"},
+        {"genome_uuid": "ef91505c-33b6-4eb2-956c-513c0772e658"},
+        {"genome_uuid": "efea712c-8fca-4d71-a7fb-f15b98402377"},
+        {"genome_uuid": "f03a7d93-051e-4e02-8171-9363be133ffe"},
+        {"genome_uuid": "f422268b-9c50-4ff8-8e69-922128901458"},
+        {"genome_uuid": "f6e984dd-f7ba-457f-ba24-65e906f98d36"},
+        {"genome_uuid": "fbb7fa5b-13fd-446f-875d-ddb2ab1f271d"},
+    ]

--- a/tests/api/resources/test_routes.py
+++ b/tests/api/resources/test_routes.py
@@ -58,36 +58,35 @@ def test_get_genome_counts():
     assert response.status_code == 200
     assert response.json() == (
         {
-            'counts': [
+            "counts": [
                 {
-                    'count': 4207,
-                    'label': 'Animals',
+                    "count": 4207,
+                    "label": "Animals",
                 },
                 {
-                    'count': 24,
-                    'label': 'Archaea',
+                    "count": 24,
+                    "label": "Archaea",
                 },
                 {
-                    'count': 85,
-                    'label': 'Bacteria',
+                    "count": 85,
+                    "label": "Bacteria",
                 },
                 {
-                    'count': 153,
-                    'label': 'Fungi',
+                    "count": 153,
+                    "label": "Fungi",
                 },
                 {
-                    'count': 465,
-                    'label': 'Green Plants',
+                    "count": 465,
+                    "label": "Green Plants",
                 },
                 {
-                    'count': 43,
-                    'label': 'Others',
+                    "count": 43,
+                    "label": "Others",
                 },
             ],
-            'total': 4977,
+            "total": 4977,
         }
     )
-
 
     response = client.get("/api/metadata/genome_counts?release=2023-10-18")
     assert response.status_code == 200
@@ -928,14 +927,8 @@ def test_explain_genome():
         "species_taxonomy_id": "9606",
         "type": None,
         "is_reference": True,
-        "assembly": {
-            "accession_id": "GCA_000001405.29",
-            "name": "GRCh38.p14"
-        },
-        "release": {
-            "name": "2025-02",
-            "type": "integrated"
-        },
+        "assembly": {"accession_id": "GCA_000001405.29", "name": "GRCh38.p14"},
+        "release": {"name": "2025-02", "type": "integrated"},
         "latest_genome": {
             "genome_id": "be73075e-0633-471d-b7c8-4f8ca7752a04",
             "genome_tag": None,
@@ -949,11 +942,7 @@ def test_explain_genome():
                 "name": "GRCh38.p14",
                 "url": "https://identifiers.org/insdc.gca/GCA_000001405.29",
             },
-            "release": {
-                "name": "2026-01-26",
-                "type": "partial",
-                "is_current": False
-            },
+            "release": {"name": "2026-01-26", "type": "partial", "is_current": False},
         },
     }
 
@@ -1043,7 +1032,9 @@ def test_example_objects(benchmark):
         {"type": "location", "id": "Chromosome:3140311-3140799"},
     ]
 
-    runnable = lambda: client.get("/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/example_objects")
+    runnable = lambda: client.get(
+        "/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/example_objects"
+    )
     benchmark(runnable)
 
 
@@ -1461,7 +1452,9 @@ def test_get_metadata_statistics(benchmark):
         }
     }
 
-    runnable = lambda: client.get("/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/stats")
+    runnable = lambda: client.get(
+        "/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/stats"
+    )
     benchmark(runnable)
 
 

--- a/tests/api/resources/test_routes.py
+++ b/tests/api/resources/test_routes.py
@@ -1503,45 +1503,34 @@ def test_get_metadata_statistics(benchmark):
 
 
 def test_get_genome_group_categories():
-    response = client.get("/api/metadata/get_genome_group_categories")
+    response = client.get("/api/metadata/genome_group_categories")
     assert response.status_code == 200
     assert response.json() == {
         "group_categories": [
             {
                 "display_name": "External projects",
-                "type": "external_projects",
+                "type": "project",
                 "groups": [
                     {
-                        "group_id": 1,
-                        "title": "AQUA-FAANG",
-                        "description": "Short project description",
+                        "group_id": 12,
+                        "title": "Vertebrate Genomes Project (VGP)",
+                        "description": "The Vertebrate Genomes Project (VGP) is an international effort to generate near error-free, high-quality reference genome assemblies for all ~70,000 extant vertebrate species, advancing biology, conservation, and disease research.",
                         "rank": 1,
-                        "genomes_count": 15,
+                        "genomes_count": 399,
                     },
                     {
-                        "group_id": 2,
-                        "title": "Aquatic Symbiosis Genomics Project",
-                        "description": "Short project description",
+                        "group_id": 13,
+                        "title": "Biodiversity Genomics Europe (BGE)",
+                        "description": "The ERGA-BGE project accelerates genomic science across Europe by generating high-quality reference genomes for biodiversity, supporting conservation, monitoring, and research as part of the Biodiversity Genomics Europe and Earth BioGenome initiatives.",
                         "rank": 2,
-                        "genomes_count": 11,
-                    },
-                ],
-            },
-            {
-                "display_name": "Ensembl genome collections",
-                "type": "genome_collections",
-                "groups": [
-                    {
-                        "group_id": 3,
-                        "title": "Animal pathogens",
-                        "rank": 1,
-                        "genomes_count": 20,
+                        "genomes_count": 63,
                     },
                     {
-                        "group_id": 4,
-                        "title": "Apes",
-                        "rank": 2,
-                        "genomes_count": 412,
+                        "group_id": 14,
+                        "title": "Ancient Environmental Genomics Initiative for Sustainability (AEGIS)",
+                        "description": "AEGIS is a global research consortium using ancient environmental DNA and genomics to uncover past adaptations and genetic diversity, guiding development of climate-resilient crops and sustainable food systems under climate change.",
+                        "rank": 3,
+                        "genomes_count": 79,
                     },
                 ],
             },

--- a/uv.lock
+++ b/uv.lock
@@ -354,6 +354,7 @@ dev = [
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
+    { name = "pytest-profiling" },
 ]
 
 [package.metadata]
@@ -385,6 +386,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
+    { name = "pytest-profiling", specifier = ">=1.8.1" },
 ]
 
 [[package]]
@@ -413,6 +415,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
+]
+
+[[package]]
+name = "gprof2dot"
+version = "2025.4.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/fd/cad13fa1f7a463a607176432c4affa33ea162f02f58cc36de1d40d3e6b48/gprof2dot-2025.4.14.tar.gz", hash = "sha256:35743e2d2ca027bf48fa7cba37021aaf4a27beeae1ae8e05a50b55f1f921a6ce", size = 39536, upload-time = "2025-04-14T07:21:45.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/ed/89d760cb25279109b89eb52975a7b5479700d3114a2421ce735bfb2e7513/gprof2dot-2025.4.14-py3-none-any.whl", hash = "sha256:0742e4c0b4409a5e8777e739388a11e1ed3750be86895655312ea7c20bd0090e", size = 37555, upload-time = "2025-04-14T07:21:43.319Z" },
 ]
 
 [[package]]
@@ -937,6 +948,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
+]
+
+[[package]]
+name = "pytest-profiling"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gprof2dot" },
+    { name = "pytest" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/74/806cafd6f2108d37979ec71e73b2ff7f7db88eabd19d3b79c5d6cc229c36/pytest-profiling-1.8.1.tar.gz", hash = "sha256:3f171fa69d5c82fa9aab76d66abd5f59da69135c37d6ae5bf7557f1b154cb08d", size = 33135, upload-time = "2024-11-29T19:34:13.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/ac/c428c66241a144617a8af7a28e2e055e1438d23b949b62ac4b401a69fb79/pytest_profiling-1.8.1-py3-none-any.whl", hash = "sha256:3dd8713a96298b42d83de8f5951df3ada3e61b3e5d2a06956684175529e17aea", size = 9929, upload-time = "2024-11-29T19:33:02.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Changes
This PR introduces `/genome_group_categories` endpoint

For now, we're mocking the `order` and `display_name` of genome group categories (top level/tabs in the UI)
This will be adressed in a later PR once we have the data ready
The genome groups' info is coming from the DB as desired

### Example
Query
```
http://127.0.0.1:8000/api/metadata/genome_group_categories
```

Response
```
{
  "group_categories": [
    {
      "display_name": "External projects",
      "type": "project",
      "groups": [
        {
          "group_id": 12,
          "title": "Vertebrate Genomes Project (VGP)",
          "description": "The Vertebrate Genomes Project (VGP) is an international effort to generate near error-free, high-quality reference genome assemblies for all ~70,000 extant vertebrate species, advancing biology, conservation, and disease research.",
          "rank": 1,
          "genomes_count": 399
        },
        {
          "group_id": 13,
          "title": "Biodiversity Genomics Europe (BGE)",
          "description": "The ERGA-BGE project accelerates genomic science across Europe by generating high-quality reference genomes for biodiversity, supporting conservation, monitoring, and research as part of the Biodiversity Genomics Europe and Earth BioGenome initiatives.",
          "rank": 2,
          "genomes_count": 63
        },
        {
          "group_id": 14,
          "title": "Ancient Environmental Genomics Initiative for Sustainability (AEGIS)",
          "description": "AEGIS is a global research consortium using ancient environmental DNA and genomics to uncover past adaptations and genetic diversity, guiding development of climate-resilient crops and sustainable food systems under climate change.",
          "rank": 3,
          "genomes_count": 79
        }
      ]
    }
  ]
}
```