### PR TITLE
Make annotation provider url nullable

### DIFF
--- a/src/api/schemas/genome.py
+++ b/src/api/schemas/genome.py
@@ -53,7 +53,7 @@ class AssemblyProvider(BaseModel):
 
     @field_serializer("url")
     def serialize_url(self, url: Optional[str]):
-        if url in ("", None):
+        if not url:
             return None
         return url
 
@@ -64,7 +64,7 @@ class AnnotationProvider(BaseModel):
 
     @field_serializer("url")
     def serialize_url(self, url: Optional[str]):
-        if url in ("", None):
+        if not url:
             return None
         return url
 

--- a/src/api/schemas/genome.py
+++ b/src/api/schemas/genome.py
@@ -49,22 +49,22 @@ class AssemblyInGenome(BaseModel):
 
 class AssemblyProvider(BaseModel):
     name: str
-    url: str = Field(alias="url", default="")
+    url: Optional[str] = Field(alias="url", default=None)
 
     @field_serializer("url")
-    def serialize_url(self, url: str):
-        if url == "":
+    def serialize_url(self, url: Optional[str]):
+        if url in ("", None):
             return None
         return url
 
 
 class AnnotationProvider(BaseModel):
     name: str
-    url: str = Field(alias="url", default="")
+    url: Optional[str] = Field(alias="url", default=None)
 
     @field_serializer("url")
-    def serialize_url(self, url: str):
-        if url == "":
+    def serialize_url(self, url: Optional[str]):
+        if url in ("", None):
             return None
         return url
 

--- a/tests/api/schemas/test_genome.py
+++ b/tests/api/schemas/test_genome.py
@@ -1,0 +1,43 @@
+from api.schemas.genome import GenomeDetails
+
+
+def minimal_genome_details_data():
+    return {
+        "genome_uuid": "4273b9f0-c927-4215-87bf-828ef65de98",
+        "organism": {
+            "scientific_name": "Example species",
+            "species_taxonomy_id": 1234,
+            "taxonomy_id": 1234,
+        },
+        "assembly": {
+            "accession": "GCA_000001405.29",
+            "name": "Example assembly",
+            "is_reference": False,
+        },
+        "release": {
+            "release_label": "2026-05",
+            "release_type": "integrated",
+        },
+        "attributes_info": {
+            "assembly_level": "chromosome",
+            "assembly_provider_name": "Assembly Provider",
+            "assembly_provider_url": None,
+            "genebuild_provider_name": "Annotation Provider",
+            "genebuild_provider_url": None,
+        },
+    }
+
+
+def test_genome_details_accepts_null_provider_urls():
+    genome_details = GenomeDetails(**minimal_genome_details_data())
+
+    data = genome_details.model_dump()
+
+    assert data["assembly_provider"] == {
+        "name": "Assembly Provider",
+        "url": None,
+    }
+    assert data["annotation_provider"] == {
+        "name": "Annotation Provider",
+        "url": None,
+    }


### PR DESCRIPTION
### Description
This PR makes `AnnotationProvider.url` and `AssemblyProvider.url` fields nullable

### Related JIRA Issue(s)
Slack discussion: https://genomes-ebi.slack.com/archives/C010QF119N1/p1778066375020989

### Review App URL(s) 
http://__BRANCH_NAME_HERE__.review.ensembl.org

### Example(s)
This should fix the `/details` endpoint called in: https://beta.ensembl.org/species/4273b9f0-c927-4215-87bf-828ef65de984