### PR TITLE
Bugfix process stats

### DIFF
--- a/src/api/models/logic.py
+++ b/src/api/models/logic.py
@@ -40,7 +40,6 @@ def get_top_level_statistics_by_uuid(db_conn, genome_uuid):
     )
 
     statistics = []
-    # FIXME stats_results can contain multiple entries
     if len(stats_results) > 0:
         for result in stats_results:
             for dataset in result.datasets:

--- a/src/api/models/logic.py
+++ b/src/api/models/logic.py
@@ -42,17 +42,17 @@ def get_top_level_statistics_by_uuid(db_conn, genome_uuid):
     statistics = []
     # FIXME stats_results can contain multiple entries
     if len(stats_results) > 0:
-
-        for dataset in stats_results[0].datasets:
-            for attribute in dataset.attributes:
-                statistics.append(
-                    {
-                        "name": attribute.name,
-                        "label": attribute.label,
-                        "statistic_type": attribute.type,
-                        "statistic_value": attribute.value,
-                    }
-                )
+        for result in stats_results:
+            for dataset in result.datasets:
+                for attribute in dataset.attributes:
+                    statistics.append(
+                        {
+                            "name": attribute.name,
+                            "label": attribute.label,
+                            "statistic_type": attribute.type,
+                            "statistic_value": attribute.value,
+                        }
+                    )
 
         statistics.sort(key=lambda x: x["name"])
 


### PR DESCRIPTION
### Description
Tiny PR to fix processing statistics from all results instead of only the first

### Dependencies 
Changes where initiated by @dpopleton in this PR: https://github.com/Ensembl/ensembl-metadata-api/pull/219

> Q: But why do we have the same function duplicated in both `ensembl-metadata-api` and this repo?
> A: Short Ensembl answer: _For historical reasons_ ..
> I would love to (at some point) do a clean up .. that will drastically shrink and simplify the gRPC logic in `ensembl-metadata-api`