### PR TITLE
Added sql to update url_name based on accession

### DIFF
--- a/sql/011_overwrite_url_name.sql
+++ b/sql/011_overwrite_url_name.sql
@@ -1,5 +1,10 @@
 # Overwrite url_name for integrated genomes setting it to assembly.accession. 
 # WARNING! This can create duplicates that need to be addressed by the accession-map script
+
+# Clear existing url_names
+UPDATE genome SET url_name = '';
+
+# Set url_name to accession for current integrated genomes
 WITH accession_map as (SELECT g.genome_id, a.accession
 FROM genome g
 JOIN assembly a ON g.assembly_id = a.assembly_id
@@ -8,4 +13,4 @@ JOIN ensembl_release er ON gr.release_id = er.release_id
 WHERE er.release_type = 'integrated' and er.is_current = 1 and g.suppressed = 0)
 UPDATE genome SET url_name = accession_map.accession
 FROM accession_map
-where genome.genome_id = accession_map.genome_id
+where genome.genome_id = accession_map.genome_id;

--- a/sql/011_overwrite_url_name.sql
+++ b/sql/011_overwrite_url_name.sql
@@ -10,7 +10,7 @@ FROM genome g
 JOIN assembly a ON g.assembly_id = a.assembly_id
 JOIN genome_release gr ON g.genome_id = gr.genome_id
 JOIN ensembl_release er ON gr.release_id = er.release_id
-WHERE er.release_type = 'integrated' and er.is_current = 1 and g.suppressed = 0)
+WHERE er.release_type = 'integrated' and er.is_current = 1)
 UPDATE genome SET url_name = accession_map.accession
 FROM accession_map
 WHERE genome.genome_id = accession_map.genome_id;

--- a/sql/011_overwrite_url_name.sql
+++ b/sql/011_overwrite_url_name.sql
@@ -13,4 +13,4 @@ JOIN ensembl_release er ON gr.release_id = er.release_id
 WHERE er.release_type = 'integrated' and er.is_current = 1 and g.suppressed = 0)
 UPDATE genome SET url_name = accession_map.accession
 FROM accession_map
-where genome.genome_id = accession_map.genome_id;
+WHERE genome.genome_id = accession_map.genome_id;

--- a/sql/011_overwrite_url_name.sql
+++ b/sql/011_overwrite_url_name.sql
@@ -1,0 +1,11 @@
+# Overwrite url_name for integrated genomes setting it to assembly.accession. 
+# WARNING! This can create duplicates that need to be addressed by the accession-map script
+WITH accession_map as (SELECT g.genome_id, a.accession
+FROM genome g
+JOIN assembly a ON g.assembly_id = a.assembly_id
+JOIN genome_release gr ON g.genome_id = gr.genome_id
+JOIN ensembl_release er ON gr.release_id = er.release_id
+WHERE er.release_type = 'integrated' and er.is_current = 1 and g.suppressed = 0)
+UPDATE genome SET url_name = accession_map.accession
+FROM accession_map
+where genome.genome_id = accession_map.genome_id


### PR DESCRIPTION
This PR adds a SQL script that when run will clear existing genome.url_name and then set url_name to the assembly.accession for any un-suppressed current integrated genome

Used in the same way as the existing script

```
duckdb -bail -f 011_overwrite_url_name.sql my_pet.duckdb
``` 