### PR TITLE
Update uv lock

### DIFF
--- a/.github/workflows/update-git-dependencies.yml
+++ b/.github/workflows/update-git-dependencies.yml
@@ -1,0 +1,37 @@
+name: Update ensembl-metadata-api dependency
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1-5"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.8.5"
+
+      - name: Update ensembl-metadata-api
+        run: uv lock --upgrade-package ensembl-metadata-api
+
+      - name: Create update pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automated/update-ensembl-metadata-api
+          delete-branch: true
+          commit-message: "chore: update ensembl-metadata-api"
+          title: "chore: update ensembl-metadata-api"
+          body: |
+            Updates the locked ensembl-metadata-api commit from its main branch.
+          labels: dependencies

--- a/.github/workflows/update-git-dependencies.yml
+++ b/.github/workflows/update-git-dependencies.yml
@@ -1,4 +1,4 @@
-name: Update ensembl-metadata-api dependency
+name: Update Git dependencies
 
 on:
   workflow_dispatch:
@@ -22,16 +22,17 @@ jobs:
         with:
           version: "0.8.5"
 
-      - name: Update ensembl-metadata-api
-        run: uv lock --upgrade-package ensembl-metadata-api
+      - name: Update Git dependencies
+        run: uv lock --upgrade-package ensembl-metadata-api --upgrade-package ensembl-py
 
       - name: Create update pull request
         uses: peter-evans/create-pull-request@v7
         with:
-          branch: automated/update-ensembl-metadata-api
+          branch: automated/update-git-dependencies
           delete-branch: true
-          commit-message: "chore: update ensembl-metadata-api"
-          title: "chore: update ensembl-metadata-api"
+          commit-message: "chore: update Git dependencies"
+          title: "chore: update Git dependencies"
           body: |
-            Updates the locked ensembl-metadata-api commit from its main branch.
+            Updates the locked commits for ensembl-metadata-api and ensembl-py
+            from their configured Git branches.
           labels: dependencies

--- a/uv.lock
+++ b/uv.lock
@@ -281,7 +281,7 @@ wheels = [
 [[package]]
 name = "ensembl-metadata-api"
 version = "3.0.0"
-source = { git = "https://github.com/Ensembl/ensembl-metadata-api?branch=main#fccf954fc9252e7d8db6bd993fc838495856f5da" }
+source = { git = "https://github.com/Ensembl/ensembl-metadata-api?branch=main#9370e0935a15ab7dea8acb5dd81ccca1938d50c6" }
 dependencies = [
     { name = "duckdb" },
     { name = "duckdb-engine" },


### PR DESCRIPTION
### Description
Git dependencies were remaining pinned to old commits in `uv.lock`, so new changes from their upstream branches were not included in builds. 

This PR:
* Updates the `uv.lock` to latest (
   * I ran this command locally: `uv lock --upgrade-package ensembl-metadata-api`
* While I'm on it I also adds a scheduled GitHub Actions workflow that updates the locked commits for both `ensembl-metadata-api` and `ensembl-py` each weekday and automatically opens or updates a PR, while preserving reproducible builds with `uv sync --locked`