### PR TITLE
Fix null chromosome ranks in top-regions

### DIFF
--- a/src/api/models/logic.py
+++ b/src/api/models/logic.py
@@ -83,13 +83,14 @@ def get_top_level_regions(adaptor: GenomeAdaptor, genome_uuid: str):
         genome_top_level_regions.append(tlr)
 
     # Sort the list of regions by two criteria:
-    # 1. By "rank" if present, regions without a rank are considered to have the highest possible rank (so they go last)
+    # 1. By "rank" if present. Missing and null ranks are considered to have
+    #    the highest possible rank (so they go last).
     # 2. Then by "length", which is stored as a string, so we convert it to an integer for proper numeric sorting
     genome_top_level_regions.sort(
         key=lambda region: (
-            # Use the value of "rank" if it exists, otherwise use infinity
-            # This ensures regions without a rank are placed at the end of the list
-            region.get("rank", float("inf")),
+            # A present rank can still be null in metadata; normalize it so
+            # Python never compares an integer with None.
+            region["rank"] if region.get("rank") is not None else float("inf"),
             # Convert the "length" from string to integer so numeric comparison works correctly
             # If "length" is missing, treat it as 0
             int(region.get("length", 0)),
@@ -130,7 +131,7 @@ def get_top_regions(
     if chromosome_regions:
         chromosome_regions.sort(
             key=lambda region: (
-                region.get("rank", float("inf")),
+                region["rank"] if region.get("rank") is not None else float("inf"),
                 region["name"],
             )
         )

--- a/tests/api/resources/test_routes.py
+++ b/tests/api/resources/test_routes.py
@@ -19,6 +19,7 @@ from fastapi.testclient import TestClient
 from api.main import app
 
 import api.config as config
+import api.models.logic as logic
 import api.resources.redis as redis_resource
 import api.resources.routes as routes_resource
 
@@ -1543,6 +1544,21 @@ def test_get_genome_top_regions():
         "Y",
         "MT",
     ]
+
+
+def test_get_top_regions_sorts_null_chromosome_ranks_last(monkeypatch):
+    monkeypatch.setattr(
+        logic,
+        "assembly_region_iterator",
+        lambda *_: iter([
+            {"name": "unranked", "chromosomal": 1, "length": "100", "rank": None},
+            {"name": "1", "chromosomal": 1, "length": "100", "rank": 1},
+        ]),
+    )
+
+    regions = logic.get_top_regions(adaptor=None, genome_uuid="test-genome")
+
+    assert [region["name"] for region in regions] == ["1", "unranked"]
 
 
 def test_get_metadata_statistics(benchmark):


### PR DESCRIPTION
### Description
Normalize null `chromosome_rank` values before Python sorting, treating them like missing ranks and placing them last. This prevents:

> TypeError: '<' not supported between instances of 'int' and 'NoneType' 

For genomes containing unranked chromosome records.  

### Related JIRA Issue(s)
[Slack](https://genomes-ebi.slack.com/archives/C07UB9J6NLR/p1785921103363399)


### Example(s)
Query
```shell
http://127.0.0.1:8000/api/metadata/genome/4d9915bc-310a-4fa4-b652-b2dbbd8912ca/top-regions
```

Response (the null-ranked region `00` last):
```json
[
  {
    "name": "1",
    "type": "chromosome",
    "length": 88663952,
    "is_circular": false
  },
  {
    "name": "2",
    "type": "chromosome",
    "length": 48614681,
    "is_circular": false
  },
  {
    "name": "3",
    "type": "chromosome",
    "length": 62190286,
    "is_circular": false
  },
  {
    "name": "4",
    "type": "chromosome",
    "length": 72208621,
    "is_circular": false
  },
  {
    "name": "5",
    "type": "chromosome",
    "length": 52070158,
    "is_circular": false
  },
  {
    "name": "6",
    "type": "chromosome",
    "length": 59532096,
    "is_circular": false
  },
  {
    "name": "7",
    "type": "chromosome",
    "length": 56760843,
    "is_circular": false
  },
  {
    "name": "8",
    "type": "chromosome",
    "length": 56938457,
    "is_circular": false
  },
  {
    "name": "9",
    "type": "chromosome",
    "length": 61540751,
    "is_circular": false
  },
  {
    "name": "10",
    "type": "chromosome",
    "length": 59756223,
    "is_circular": false
  },
  {
    "name": "11",
    "type": "chromosome",
    "length": 45475667,
    "is_circular": false
  },
  {
    "name": "12",
    "type": "chromosome",
    "length": 61165649,
    "is_circular": false
  },
  {
    "name": "00",
    "type": "chromosome",
    "length": 85736662,
    "is_circular": false
  }
]
```