### PR TITLE
Return 404 for missing genome resources

### DIFF
--- a/src/api/resources/routes.py
+++ b/src/api/resources/routes.py
@@ -223,6 +223,8 @@ async def get_genome_ftplinks(
 ):
     try:
         ftplinks_dict = get_ftp_links(adaptor, genome_uuid, "all", None)
+        if ftplinks_dict is None:
+            return response_error_handler({"status": 404})
 
         # This is temporary solution to hide regulation ftp links
         # It should be removed once the ftp links for regulation is fixed
@@ -327,7 +329,7 @@ async def get_genome_dataset_attributes(
         dataset_attributes = get_dataset_attributes(
             adaptor, genome_uuid, dataset_type, attribute_names
         )
-        if len(dataset_attributes.get("attributes", [])) == 0:
+        if not dataset_attributes or len(dataset_attributes.get("attributes", [])) == 0:
             return responses.JSONResponse(
                 {
                     "message": f"Could not find details for genome {genome_uuid} and dataset {dataset_type}."
@@ -389,7 +391,7 @@ async def get_vep_file_paths(
 ):
     try:
         vep_file_paths = get_vep_paths_by_uuid(adaptor, genome_uuid)
-        if len(vep_file_paths) == 0:
+        if not vep_file_paths:
             return responses.JSONResponse(
                 {"message": f"Could not find VEP file paths for genome {genome_uuid}."},
                 status_code=404,

--- a/src/api/resources/routes.py
+++ b/src/api/resources/routes.py
@@ -300,6 +300,8 @@ async def get_region_checksum(
         region_checksum_dict = genome_assembly_sequence_region(
             db_conn=adaptor, genome_uuid=genome_uuid, sequence_region_name=region_name
         )
+        if region_checksum_dict is None:
+            return response_error_handler({"status": 404})
         region_checksum = Checksum(**region_checksum_dict)
         return responses.PlainTextResponse(region_checksum.md5)
     except ValidationError as e:

--- a/tests/api/resources/test_routes.py
+++ b/tests/api/resources/test_routes.py
@@ -986,6 +986,13 @@ def test_get_region_checksum():
     assert response.content.decode("utf-8") == "2648ae1bacce4ec4b6cf337dcae37816"
 
 
+def test_get_region_checksum_returns_404_when_region_is_not_found():
+    response = client.get(
+        "/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/checksum/not-a-region"
+    )
+    assert response.status_code == 404
+
+
 def test_explain_genome():
     response = client.get(
         "/api/metadata/genome/a7335667-93e7-11ec-a39d-005056b38ce3/explain"

--- a/tests/api/resources/test_routes.py
+++ b/tests/api/resources/test_routes.py
@@ -443,6 +443,13 @@ def test_get_vep_file_paths():
     }
 
 
+def test_get_vep_file_paths_returns_404_when_genome_is_not_found():
+    response = client.get(
+        "/api/metadata/genome/47b8c945-5ffc-4aa0-a299-28ff6238c1fb-foo/vep/file_paths"
+    )
+    assert response.status_code == 404
+
+
 def test_get_genome_by_keyword():
     response = client.get(
         "/api/metadata/genomeid?assembly_accession_id=GCA_000001405.29"
@@ -1089,6 +1096,13 @@ def test_explain_genome_by_uuid_is_case_insensitive():
     assert response.json()["genome_id"] == "a7335667-93e7-11ec-a39d-005056b38ce3"
 
 
+def test_get_genome_dataset_attributes_returns_404_when_genome_is_not_found():
+    response = client.get(
+        "/api/metadata/genome/47b8c945-5ffc-4aa0-a299-28ff6238c1fb-foo/dataset/bar/attributes"
+    )
+    assert response.status_code == 404
+
+
 def test_explain_genome_by_url_slug_returns_404():
     response = client.get("/api/metadata/genome/grch38/explain")
     assert response.status_code == 404
@@ -1121,6 +1135,13 @@ def test_get_genome_ftplinks():
             "url": "https://ftp.ebi.ac.uk/pub/ensemblorganisms/Homo_sapiens/GCA_000001405.29/ensembl/variation/2023_03",
         },
     ]
+
+
+def test_get_genome_ftplinks_returns_404_when_genome_is_not_found():
+    response = client.get(
+        "/api/metadata/genome/47b8c945-5ffc-4aa0-a299-28ff6238c1fb-foo/ftplinks"
+    )
+    assert response.status_code == 404
 
 
 def test_get_genome_details():


### PR DESCRIPTION
Fixes several metadata endpoints that returned 500 when a requested genome or resource was not found.

* Return 404 for missing checksum regions
* Return 404 for missing VEP file paths
* Return 404 for missing FTP links
* Return 404 for missing dataset attributes
* Add regression tests for each case